### PR TITLE
algorithm.hpp header fixes

### DIFF
--- a/include/rstl/algorithm.hpp
+++ b/include/rstl/algorithm.hpp
@@ -1,18 +1,10 @@
-#ifndef _RSTL_MATH_HPP
-#define _RSTL_MATH_HPP
+#ifndef _RSTL_ALGORITHM_HPP
+#define _RSTL_ALGORITHM_HPP
 
 #include "rstl/pointer_iterator.hpp"
 
 namespace rstl {
 template < typename T >
-inline const T& min_val(const T& a, const T& b) {
-  return (b < a) ? b : a;
-}
-
-template < typename T >
-inline const T& max_val(const T& a, const T& b) {
-  return (a < b) ? b : a;
-}
 
 template < class Iter, class T >
 inline Iter find(Iter first, Iter last, const T& val) {
@@ -21,4 +13,4 @@ inline Iter find(Iter first, Iter last, const T& val) {
   return first;
 }
 } // namespace rstl
-#endif // _RSTL_MATH_HPP
+#endif // _RSTL_ALGORITHM_HPP

--- a/include/rstl/math.hpp
+++ b/include/rstl/math.hpp
@@ -5,12 +5,13 @@
 
 namespace rstl {
 template < typename T >
-static inline const T& max_val(const T& a, const T& b) {
-  return a > b ? a : b;
+inline const T& min_val(const T& a, const T& b) {
+  return (b < a) ? b : a;
 }
+
 template < typename T >
-static inline const T& min_val(const T& a, const T& b) {
-  return a < b ? a : b;
+inline const T& max_val(const T& a, const T& b) {
+  return (a < b) ? b : a;
 }
 } // namespace rstl
 

--- a/src/Kyoto/Graphics/DolphinCColor.cpp
+++ b/src/Kyoto/Graphics/DolphinCColor.cpp
@@ -2,7 +2,7 @@
 
 #include "Kyoto/Streams/CInputStream.hpp"
 
-#include "rstl/algorithm.hpp"
+#include "rstl/math.hpp"
 
 CColor::CColor(CInputStream& in) {
   float r = in.ReadFloat();


### PR DESCRIPTION
`algorithm.hpp` was using the ifdef guards from `math.hpp`
The implementations from math.hpp causes `DolphinCColor.cpp` to not match properly