### PR TITLE
Match CFontRenderState, can't link due to ordering

### DIFF
--- a/include/Kyoto/Text/CFontRenderState.hpp
+++ b/include/Kyoto/Text/CFontRenderState.hpp
@@ -27,13 +27,14 @@ private:
 class CFontRenderState {
 public:
   CFontRenderState();
+  void RefreshColor(EColorType col);
   uint ConvertToTextureSpace(const CTextColor& color) const;
   void PushState();
   void PopState();
   void SetColor(EColorType type, const CTextColor& color);
   void RefreshPalette();
   CDrawStringOptions& GetOptions() { return x0_state.GetOptions(); }
-  TToken< CRasterFont >& GetFont() { return x0_state.GetFont(); }
+  TToken< CRasterFont >& GetFont() { return *x0_state.GetFont(); }
   void SetFont(const TToken< CRasterFont >& font) { x0_state.SetFont(font); }
   rstl::vector< CTextColor >& GetColors() { return x0_state.GetColors(); }
   rstl::vector< bool >& GetOverride() { return x0_state.GetOverride(); }

--- a/include/Kyoto/Text/CSaveableState.hpp
+++ b/include/Kyoto/Text/CSaveableState.hpp
@@ -14,7 +14,7 @@ public:
   bool IsFinishedLoading();
 
   CDrawStringOptions& GetOptions() { return x0_drawStringOptions; }
-  TToken<CRasterFont>& GetFont() { return *x48_font; }
+  rstl::optional_object< TToken< CRasterFont > >& GetFont() { return x48_font; }
   void SetFont(const TToken<CRasterFont>& font) { x48_font = font; }
   rstl::vector<CTextColor>& GetColors() { return x54_colors; }
   rstl::vector<bool>& GetOverride() { return x64_colorOverrides; }
@@ -22,7 +22,7 @@ public:
   void SetLineExtraSpace(int spacing) { x78_extraLineSpacing = spacing; }
 
   
-private:
+//private:
   CDrawStringOptions x0_drawStringOptions;
   rstl::optional_object< TToken< CRasterFont > > x48_font;
   rstl::vector< CTextColor > x54_colors;

--- a/include/Kyoto/Text/CTextColor.hpp
+++ b/include/Kyoto/Text/CTextColor.hpp
@@ -9,6 +9,7 @@
 
 class CTextColor {
 public:
+  // TODO: Verify component ordering, there is evidence this might actually be ABGR instead of RGBA
   CTextColor(uchar r, uchar g, uchar b, uchar a) : mR(r), mG(g), mB(b), mA(a) {}
 
   CTextColor(const CTextColor& other) : mR(other.mR), mG(other.mG), mB(other.mB), mA(other.mA) {}
@@ -20,6 +21,13 @@ public:
     mA = other.mA;
     return *this;
   }
+  
+  uint GetRGBA() const { return mRgba; }
+  
+  const uchar GetAlpha() const { return mA; }
+  const uchar GetBlue() const { return mB; }
+  const uchar GetGreen() const { return mG; }
+  const uchar GetRed() const { return mR; }
 
 private:
   union {
@@ -34,7 +42,7 @@ private:
 };
 
 #ifdef __MWERKS__
-#pragma cpp_extensions off
+#pragma cpp_extensions reset
 #endif
 
 #endif // _CTEXTCOLOR

--- a/include/Kyoto/Text/TextCommon.hpp
+++ b/include/Kyoto/Text/TextCommon.hpp
@@ -6,6 +6,7 @@ enum EColorType {
   kCT_Outline,
   kCT_Geometry,
   kCT_Foreground,
+  kCT_Background,
 };
 
 enum ETextDirection {

--- a/include/rstl/construct.hpp
+++ b/include/rstl/construct.hpp
@@ -26,12 +26,13 @@ inline void destroy(It begin, It end) {
 
 template < typename It, typename T >
 inline T* uninitialized_copy(It begin, It end, T* out) {
+  T* tmp = out;
   It cur = begin;
-  for (; cur != end; ++out, ++cur) {
-    construct(out, *cur);
+  for (; cur != end; ++tmp, ++cur) {
+    construct(tmp, *cur);
   }
   
-  return out;
+  return tmp;
 }
 
 template < typename S, typename D >

--- a/src/Kyoto/Text/CFontRenderState.cpp
+++ b/src/Kyoto/Text/CFontRenderState.cpp
@@ -1,6 +1,5 @@
 #include "Kyoto/Text/CFontRenderState.hpp"
 
-#pragma inline_max_size(250)
 CFontRenderState::CFontRenderState()
 : x88_curBlock(nullptr)
 , xd4_curX(0)
@@ -13,12 +12,91 @@ CFontRenderState::CFontRenderState()
   RefreshPalette();
 }
 
-void CFontRenderState::PushState() {
-  x10c_pushedStates.push_front(x0_state);
+void CFontRenderState::RefreshColor(const EColorType col) {
+  switch (col) {
+  case kCT_Main: {
+    if (x0_state.IsFinishedLoading() && GetFont().IsLoaded()) {
+      switch (GetFont()->GetMode()) {
+      case kFM_OneLayer:
+        if (!x0_state.GetOverride()[0]) {
+          x0_state.GetOptions().SetPaletteEntry(0, ConvertToTextureSpace(x0_state.GetColors()[0]));
+        }
+        break;
+      case kFM_OneLayerOutline: {
+        if (!x0_state.GetOverride()[0]) {
+          x0_state.GetOptions().SetPaletteEntry(0, ConvertToTextureSpace(x0_state.GetColors()[0]));
+        }
+        break;
+      }
+      default:
+        break;
+      }
+    }
+    break;
+  }
+  case kCT_Geometry: {
+    if (!x0_state.GetOverride()[2]) {
+      x0_state.GetOptions().SetPaletteEntry(2, ConvertToTextureSpace(x0_state.GetColors()[2]));
+    }
+  } break;
+  case kCT_Outline: {
+    if (x0_state.IsFinishedLoading() && GetFont().IsLoaded() && !x0_state.GetOverride()[1]) {
+      if (GetFont()->GetMode() == kFM_OneLayerOutline) {
+        x0_state.GetOptions().SetPaletteEntry(1, ConvertToTextureSpace(x0_state.GetColors()[1]));
+      }
+    }
+    break;
+  }
+
+  case kCT_Foreground: {
+    RefreshColor(kCT_Main);
+    RefreshColor(kCT_Geometry);
+    break;
+  }
+  case kCT_Background: {
+    RefreshColor(kCT_Outline);
+    break;
+  }
+  }
 }
+void CFontRenderState::RefreshPalette() {
+  RefreshColor(kCT_Foreground);
+  RefreshColor(kCT_Background);
+}
+
+void CFontRenderState::SetColor(const EColorType type, const CTextColor& color) {
+  switch (type) {
+  case kCT_Main:
+  case kCT_Outline:
+  case kCT_Geometry:
+    x0_state.GetColors()[type] = color;
+    break;
+  case kCT_Foreground:
+    x0_state.GetColors()[0] = color;
+    break;
+  case kCT_Background:
+    x0_state.GetColors()[1] = color;
+    break;
+  }
+
+  RefreshColor(type);
+}
+
+void CFontRenderState::PushState() { x10c_pushedStates.push_front(x0_state); }
 
 void CFontRenderState::PopState() {
   x0_state = *x10c_pushedStates.begin();
   x10c_pushedStates.pop_front();
   RefreshPalette();
 }
+
+#ifdef __MWERKS__
+#pragma cpp_extensions reset
+#endif
+uint CFontRenderState::ConvertToTextureSpace(const CTextColor& color) const {
+  return CTextColor(color).GetRGBA();
+}
+
+#ifdef __MWERKS__
+#pragma cpp_extensions reset
+#endif


### PR DESCRIPTION
This gets `CFontRenderState` functionally identical and nearly byte exact, but can't be linked due to ordering issues with `rstl::vector` and `rstl::single_ptr` (`rstl::destroy` not getting inlined for `rstl::single_ptr<CSaveableState>`)

This needs some investigation, it seems to be related to the typedef and constructor behavior I discovered recently.