### PR TITLE
Document string operator placement

### DIFF
--- a/src/Kyoto/Audio/CStreamAudioManager.cpp
+++ b/src/Kyoto/Audio/CStreamAudioManager.cpp
@@ -321,6 +321,7 @@ void CStreamAudioManager::SetSfxVolume(uint vol) {
   }
 }
 
+// TODO: Move to rstl/string.hpp once header inlining preserves the helper and FadeBackIn codegen.
 bool rstl::operator!=(const rstl::string& lhs, const char* rhs) { return lhs.compare(rhs) != 0; }
 
 void CStreamAudioManager::FadeBackIn(float fadeTime) {

--- a/src/MetroidPrime/Enemies/CPatterned.cpp
+++ b/src/MetroidPrime/Enemies/CPatterned.cpp
@@ -736,6 +736,7 @@ void CPatterned::UpdateDamageColor(float dt) {
   }
 }
 
+// TODO: Move to rstl/string.hpp once header inlining preserves the helper and Think codegen.
 bool rstl::operator==(const char* lhs, const rstl::string& rhs) {
   return rhs.compare(lhs, -1) == 0;
 }


### PR DESCRIPTION
Follow-up to #82: header inlining removes the emitted comparison helpers and changes FadeBackIn and Think. Add TODOs at both definitions until their placement can be corrected without codegen regressions.