### PR TITLE
Match CTransform4f transpose multiply

### DIFF
--- a/include/Kyoto/Math/CTransform4f.hpp
+++ b/include/Kyoto/Math/CTransform4f.hpp
@@ -129,7 +129,10 @@ public:
   void SetRotation(const CMatrix3f& rotation);
   void SetRotation(const CTransform4f& rotation);
   CVector3f TransposeMultiply(const CVector3f& in) const {
-    return TransposeRotate(CVector3f(in.GetX() - m03, in.GetY() - m13, in.GetZ() - m23));
+    float x = in.GetX();
+    float y = in.GetY();
+    float z = in.GetZ();
+    return TransposeRotate(CVector3f(x - m03, y - m13, z - m23));
   }
   CVector3f TransposeRotate(const CVector3f& in) const;
 


### PR DESCRIPTION
Read vector components before forming the translated vector in TransposeMultiply. This restores the original load ordering when the helper is inlined into CBoneTracking.
