### PR TITLE
CSortedLists 99%

### DIFF
--- a/include/MetroidPrime/CSortedLists.hpp
+++ b/include/MetroidPrime/CSortedLists.hpp
@@ -57,7 +57,7 @@ public:
   void Insert(CActor* actor, const CAABox& box);
   void Remove(const CActor* actor);
   void Move(const CActor* actor, const CAABox& box);
-  void AddToLinkedList(short nodeId, short& headId, short& tailId) const;
+  void AddToLinkedList(const short nodeId, short& headId, short& tailId) const;
   short CalculateIntersections(ESortedLists la, ESortedLists lb, short a, short b, short c, short d,
                                ESortedLists slA, ESortedLists slB, ESortedLists slC,
                                ESortedLists slD, const CAABox& aabb) const;

--- a/src/MetroidPrime/CSortedLists.cpp
+++ b/src/MetroidPrime/CSortedLists.cpp
@@ -184,7 +184,7 @@ void CSortedListManager::Move(const CActor* actor, const CAABox& box) {
   MoveInList(kSL_MaxZ, node.x1c_selfIdxs[kSL_MaxZ]);
 }
 
-void CSortedListManager::AddToLinkedList(short nodeId, short& headId, short& tailId) const {
+void CSortedListManager::AddToLinkedList(const short nodeId, short& headId, short& tailId) const {
   if (headId == -1) {
     x0_nodes[nodeId].x28_next = headId;
     tailId = nodeId;


### PR DESCRIPTION
Match CalculateIntersections; the actor-reference BuildNearList retains a register mismatch.