### PR TITLE
Restore rstl::vector::assign inlining

### DIFF
--- a/include/rstl/vector.hpp
+++ b/include/rstl/vector.hpp
@@ -72,7 +72,7 @@ public:
   }
 
   inline void resize(int size, const T& in = T());
-  void assign(int size, const T& in = T());
+  inline void assign(int size, const T& in = T());
   void reserve(int size);
   iterator insert(iterator it, const T& value);
 

--- a/src/Weapons/CCollisionResponseData.cpp
+++ b/src/Weapons/CCollisionResponseData.cpp
@@ -1,3 +1,5 @@
+#pragma inline_max_size(250)
+
 #include "Weapons/CCollisionResponseData.hpp"
 
 #include "Kyoto/CFactoryFnReturn.hpp"


### PR DESCRIPTION
Restore vector::assign inlining to match memory-card helper emission, with the permitted inline budget preserving CCollisionResponseData.