### PR TITLE
Match & link CFluidPlane

### DIFF
--- a/config/GM8E01_00/splits.txt
+++ b/config/GM8E01_00/splits.txt
@@ -881,13 +881,18 @@ MetroidPrime/Cameras/CPathCamera.cpp:
 	.sbss       start:0x805A8F60 end:0x805A8F70
 	.sdata2     start:0x805AB5C8 end:0x805AB5E8
 
-MetroidPrime/CFluidPlaneManager.cpp:
-	.text       start:0x8012E90C end:0x8012F774
-	.rodata     start:0x803D0038 end:0x803D0048
+MetroidPrime/CFluidPlane.cpp:
+	.text       start:0x8012E90C end:0x8012F098
 	.data       start:0x803E0CE0 end:0x803E0D00
+	.sdata      start:0x805A76C8 end:0x805A76D8
+	.sdata2     start:0x805AB5E8 end:0x805AB608
+
+MetroidPrime/CFluidPlaneManager.cpp:
+	.text       start:0x8012F098 end:0x8012F774
+	.rodata     start:0x803D0038 end:0x803D0048
 	.bss        start:0x8056F8B4 end:0x805719CC align:4 common
-	.sdata      start:0x805A76C8 end:0x805A76E0
-	.sdata2     start:0x805AB5E8 end:0x805AB650
+	.sdata      start:0x805A76D8 end:0x805A76E0
+	.sdata2     start:0x805AB608 end:0x805AB650
 
 MetroidPrime/ScriptObjects/CScriptGrapplePoint.cpp:
 	.text       start:0x8012F774 end:0x8012FAD8

--- a/config/GM8E01_01/splits.txt
+++ b/config/GM8E01_01/splits.txt
@@ -881,13 +881,18 @@ MetroidPrime/Cameras/CPathCamera.cpp:
 	.sbss       start:0x805A9140 end:0x805A9150
 	.sdata2     start:0x805AB7A8 end:0x805AB7C8
 
-MetroidPrime/CFluidPlaneManager.cpp:
-	.text       start:0x8012E988 end:0x8012F7F0
-	.rodata     start:0x803D0218 end:0x803D0228
+MetroidPrime/CFluidPlane.cpp:
+	.text       start:0x8012E988 end:0x8012F114
 	.data       start:0x803E0EC0 end:0x803E0EE0
+	.sdata      start:0x805A78A8 end:0x805A78B8
+	.sdata2     start:0x805AB7C8 end:0x805AB7E8
+
+MetroidPrime/CFluidPlaneManager.cpp:
+	.text       start:0x8012F114 end:0x8012F7F0
+	.rodata     start:0x803D0218 end:0x803D0228
 	.bss        start:0x8056FA94 end:0x80571BAC align:4 common
-	.sdata      start:0x805A78A8 end:0x805A78C0
-	.sdata2     start:0x805AB7C8 end:0x805AB830
+	.sdata      start:0x805A78B8 end:0x805A78C0
+	.sdata2     start:0x805AB7E8 end:0x805AB830
 
 MetroidPrime/ScriptObjects/CScriptGrapplePoint.cpp:
 	.text       start:0x8012F7F0 end:0x8012FB54

--- a/configure.py
+++ b/configure.py
@@ -780,6 +780,7 @@ config.libs = [
                 "MetroidPrime/ScriptObjects/CScriptCoverPoint.cpp",
             ),
             Object(MatchingFor("GM8E01_00", "GM8E01_01"), "MetroidPrime/Cameras/CPathCamera.cpp"),
+            Object(MatchingFor("GM8E01_00", "GM8E01_01"), "MetroidPrime/CFluidPlane.cpp"),
             Object(NonMatching, "MetroidPrime/CFluidPlaneManager.cpp"),
             Object(
                 MatchingFor("GM8E01_00", "GM8E01_01"),

--- a/include/MetroidPrime/ScriptObjects/CScriptWater.hpp
+++ b/include/MetroidPrime/ScriptObjects/CScriptWater.hpp
@@ -86,7 +86,7 @@ public:
   int GetSplashIndex(float scale) const;
   const rstl::optional_object< TLockedToken< CGenDescription > >&
   GetSplashEffect(float scale) const;
-  int GetSplashSound(float scale) const;
+  const ushort GetSplashSound(float scale) const;
   float GetSplashEffectScale(float scale) const;
   const CColor& GetSplashColor() const { return x2a4_splashColor; }
 

--- a/src/MetroidPrime/CFluidPlane.cpp
+++ b/src/MetroidPrime/CFluidPlane.cpp
@@ -1,0 +1,104 @@
+#include "MetroidPrime/CFluidPlane.hpp"
+
+#include "MetroidPrime/CRipple.hpp"
+#include "MetroidPrime/CStateManager.hpp"
+#include "MetroidPrime/ScriptObjects/CScriptWater.hpp"
+#include "MetroidPrime/Tweaks/CTweakGame.hpp"
+
+#include "Kyoto/CResFactory.hpp"
+#include "Kyoto/CSimplePool.hpp"
+#include "Kyoto/Math/CMath.hpp"
+#include "Kyoto/SObjectTag.hpp"
+#include "rstl/math.hpp"
+
+float CFluidPlane::kRippleIntensityRange = 1.f;
+const float gkFluidMaxCrest = 0.8f;
+
+CFluidPlane::CFluidPlane(const CAssetId texPattern1, const CAssetId texPattern2,
+                         const CAssetId texColor, const float alpha, const EFluidType fluidType,
+                         const float rippleIntensity, const CFluidUVMotion& motion)
+: x4_texPattern1Id(texPattern1)
+, x8_texPattern2Id(texPattern2)
+, xc_texColorId(texColor)
+, x40_alpha(alpha)
+, x44_fluidType(fluidType)
+, x48_rippleIntensity(rippleIntensity)
+, x4c_uvMotion(motion) {
+  if (gpResourceFactory->GetResourceTypeById(x4_texPattern1Id) == FourCC('TXTR')) {
+    x10_texPattern1 = gpSimplePool->GetObj(SObjectTag(FourCC('TXTR'), x4_texPattern1Id));
+  }
+  if (gpResourceFactory->GetResourceTypeById(x8_texPattern2Id) == FourCC('TXTR')) {
+    x20_texPattern2 = gpSimplePool->GetObj(SObjectTag(FourCC('TXTR'), x8_texPattern2Id));
+  }
+  if (gpResourceFactory->GetResourceTypeById(xc_texColorId) == FourCC('TXTR')) {
+    x30_texColor = gpSimplePool->GetObj(SObjectTag(FourCC('TXTR'), xc_texColorId));
+  }
+}
+
+CFluidPlane::~CFluidPlane() {}
+
+float CFluidPlane::CalculateRippleIntensity(float base) const {
+  float mul;
+  switch (x44_fluidType) {
+  case kFT_NormalWater:
+    mul = gpTweakGame->GetRippleIntensityNormal();
+    break;
+  case kFT_PoisonWater:
+    mul = gpTweakGame->GetRippleIntensityPoison();
+    break;
+  case kFT_Lava:
+    mul = gpTweakGame->GetRippleIntensityLava();
+    break;
+  case kFT_PhazonFluid:
+  case kFT_Four:
+    mul = 0.8f;
+    break;
+  default:
+    mul = 1.f;
+    break;
+  }
+
+  float intensityRange = GetRippleIntensityRange();
+  float ret =
+      base * mul * ((intensityRange * (1.f - x48_rippleIntensity) + 1.f) - (intensityRange * 0.5f));
+  ret = rstl::min_val(rstl::max_val(ret, 0.f), 1.f);
+  return ret;
+}
+
+float CFluidPlane::GetRippleScaleFromKineticEnergy(float baseI, float velDot) {
+  const float energy = 0.5f * baseI * velDot * velDot;
+  float tmp = CMath::FastSqrtF(energy);
+  return tmp >= 160.f ? 1.f : tmp * (1.f / 160.f);
+}
+
+void CFluidPlane::AddRipple(const float mag, const TUniqueId rippler, const CVector3f& center,
+                            const CScriptWater& water, CStateManager& mgr) {
+  if (!water.CanRippleAtPoint(center)) {
+    return;
+  }
+  const float intensity = CalculateRippleIntensity(mag);
+  mgr.FluidPlaneManager()->RippleManager().AddRipple(CRipple(rippler, center, intensity));
+}
+
+void CFluidPlane::AddRipple(const float mag, const TUniqueId rippler, const CVector3f& center,
+                            const CVector3f& velocity, const CScriptWater& water,
+                            CStateManager& mgr, const CVector3f& upVec) {
+  if (!water.CanRippleAtPoint(center)) {
+    return;
+  }
+
+  float intensity = CalculateRippleIntensity(
+      GetRippleScaleFromKineticEnergy(mag, CVector3f::Dot(upVec, velocity)));
+  mgr.FluidPlaneManager()->RippleManager().AddRipple(CRipple(rippler, center, intensity));
+}
+
+void CFluidPlane::AddRipple(const CRipple& ripple, const CScriptWater& water, CStateManager& mgr) {
+  if (!water.CanRippleAtPoint(ripple.GetCenter())) {
+    return;
+  }
+
+  mgr.FluidPlaneManager()->RippleManager().AddRipple(ripple);
+}
+
+void CFluidPlane::Render(const CStateManager& mgr, const CAABox&, const CFrustumPlanes&,
+                         const CRippleManager&, const CVector3f&) {}

--- a/src/MetroidPrime/CFluidPlaneManager.cpp
+++ b/src/MetroidPrime/CFluidPlaneManager.cpp
@@ -21,8 +21,6 @@
 #include "MetroidPrime/Tweaks/CTweakGame.hpp"
 #include "rstl/math.hpp"
 
-float CFluidPlane::kRippleIntensityRange = 1.f;
-const float gkFluidMaxCrest = 0.8f;
 const bool gkWaterEnable = true;
 const bool gkWaterTurbulence = true;
 const bool gkWaterBumpMapping = true;
@@ -180,94 +178,3 @@ void CFluidPlaneManager::SetupRippleMap() {
 }
 
 uint CFluidPlaneManager::GetFreqTableIndex(float) { return 0; }
-
-CFluidPlane::CFluidPlane(const CAssetId texPattern1, const CAssetId texPattern2,
-                         const CAssetId texColor, const float alpha, const EFluidType fluidType,
-                         const float rippleIntensity, const CFluidUVMotion& motion)
-: x4_texPattern1Id(texPattern1)
-, x8_texPattern2Id(texPattern2)
-, xc_texColorId(texColor)
-, x40_alpha(alpha)
-, x44_fluidType(fluidType)
-, x48_rippleIntensity(rippleIntensity)
-, x4c_uvMotion(motion) {
-  if (gpResourceFactory->GetResourceTypeById(x4_texPattern1Id) == FourCC('TXTR')) {
-    x10_texPattern1 = gpSimplePool->GetObj(SObjectTag(FourCC('TXTR'), x4_texPattern1Id));
-  }
-  if (gpResourceFactory->GetResourceTypeById(x8_texPattern2Id) == FourCC('TXTR')) {
-    x20_texPattern2 = gpSimplePool->GetObj(SObjectTag(FourCC('TXTR'), x8_texPattern2Id));
-  }
-  if (gpResourceFactory->GetResourceTypeById(xc_texColorId) == FourCC('TXTR')) {
-    x30_texColor = gpSimplePool->GetObj(SObjectTag(FourCC('TXTR'), xc_texColorId));
-  }
-}
-
-CFluidPlane::~CFluidPlane() {}
-
-float CFluidPlane::CalculateRippleIntensity(float base) const {
-  float mul;
-  switch (x44_fluidType) {
-  case kFT_NormalWater:
-    mul = gpTweakGame->GetRippleIntensityNormal();
-    break;
-  case kFT_PoisonWater:
-    mul = gpTweakGame->GetRippleIntensityPoison();
-    break;
-  case kFT_Lava:
-    mul = gpTweakGame->GetRippleIntensityLava();
-    break;
-  case kFT_PhazonFluid:
-  case kFT_Four:
-    mul = 0.8f;
-    break;
-  default:
-    mul = 1.f;
-    break;
-  }
-
-  float intensityRange = GetRippleIntensityRange();
-  float ret =
-      base * mul * ((intensityRange * (1.f - x48_rippleIntensity) + 1.f) - (intensityRange * 0.5f));
-  ret = rstl::min_val(rstl::max_val(ret, 0.f), 1.f);
-  return ret;
-}
-
-float CFluidPlane::GetRippleScaleFromKineticEnergy(float baseI, float velDot) {
-  float tmp = CMath::FastSqrtF(0.5f * baseI * velDot * velDot);
-  if (tmp >= 160.f) {
-    return 1.f;
-  }
-  return tmp * (1.f / 160.f);
-}
-
-void CFluidPlane::AddRipple(const float mag, const TUniqueId rippler, const CVector3f& center,
-                            const CScriptWater& water, CStateManager& mgr) {
-  if (!water.CanRippleAtPoint(center)) {
-    return;
-  }
-  const float intensity = CalculateRippleIntensity(mag);
-  mgr.FluidPlaneManager()->RippleManager().AddRipple(CRipple(rippler, center, intensity));
-}
-
-void CFluidPlane::AddRipple(const float mag, const TUniqueId rippler, const CVector3f& center,
-                            const CVector3f& velocity, const CScriptWater& water,
-                            CStateManager& mgr, const CVector3f& upVec) {
-  if (!water.CanRippleAtPoint(center)) {
-    return;
-  }
-
-  float intensity = CalculateRippleIntensity(
-      GetRippleScaleFromKineticEnergy(mag, CVector3f::Dot(upVec, velocity)));
-  mgr.FluidPlaneManager()->RippleManager().AddRipple(CRipple(rippler, center, intensity));
-}
-
-void CFluidPlane::AddRipple(const CRipple& ripple, const CScriptWater& water, CStateManager& mgr) {
-  if (!water.CanRippleAtPoint(ripple.GetCenter())) {
-    return;
-  }
-
-  mgr.FluidPlaneManager()->RippleManager().AddRipple(ripple);
-}
-
-void CFluidPlane::Render(const CStateManager& mgr, const CAABox&, const CFrustumPlanes&,
-                         const CRippleManager&, const CVector3f&) {}

--- a/src/MetroidPrime/ScriptObjects/CScriptWater.cpp
+++ b/src/MetroidPrime/ScriptObjects/CScriptWater.cpp
@@ -183,7 +183,7 @@ CScriptWater::GetSplashEffect(float scale) const {
   return x264_splashEffects[GetSplashIndex(scale)];
 }
 
-int CScriptWater::GetSplashSound(float scale) const {
+const ushort CScriptWater::GetSplashSound(float scale) const {
   int idx = GetSplashIndex(scale);
   return x298_splashSounds[idx];
 }


### PR DESCRIPTION
Restore the original CFluidPlane translation-unit boundary and correct the splash sound ID return type.