### PR TITLE
Centralize Retro inlining flags

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -309,6 +309,10 @@ cflags_retro = [
     "-DMUSY_TARGET=MUSY_TARGET_DOLPHIN",
 ]
 
+# Most Retro code uses this inline limit. Objects that still need the compiler
+# default retain cflags_retro explicitly while their helper inlining is investigated.
+cflags_retro_inline = [*cflags_retro, '-pragma "inline_max_size(250)"']
+
 cflags_musyx = [
     "-proc gekko",
     "-nodefaults",
@@ -403,7 +407,7 @@ def RetroLib(lib_name, progress_category, objects):
     return {
         "lib": lib_name + "CW" + "D" if args.debug else "",
         "mw_version": "GC/1.3.2",
-        "cflags": cflags_retro,
+        "cflags": cflags_retro_inline,
         "progress_category": progress_category,
         "objects": objects,
         "shift_jis": False,
@@ -414,7 +418,7 @@ def KyotoLib(lib_name, progress_category, objects):
     return {
         "lib": lib_name + "CW" + "D" if args.debug else "",
         "mw_version": "GC/1.3.2",
-        "cflags": [*cflags_retro, "-pragma \"inline_max_size(250)\""],
+        "cflags": cflags_retro_inline,
         "host": False,
         "progress_category": progress_category,
         "objects": objects,
@@ -507,7 +511,11 @@ config.libs = [
                 "MetroidPrime/CArchMsgParmUserInput.cpp",
             ),
             Object(NonMatching, "MetroidPrime/CFrontEndUI.cpp"),
-            Object(MatchingFor("GM8E01_00", "GM8E01_01"), "MetroidPrime/CInputGenerator.cpp"),
+            Object(
+                MatchingFor("GM8E01_00", "GM8E01_01"),
+                "MetroidPrime/CInputGenerator.cpp",
+                cflags=cflags_retro,
+            ),
             Object(MatchingFor("GM8E01_00"), "MetroidPrime/CMainFlow.cpp"),
             Object(MatchingFor("GM8E01_00"), "MetroidPrime/CMFGame.cpp"),
             Object(NonMatching, "MetroidPrime/CCredits.cpp"),
@@ -577,7 +585,11 @@ config.libs = [
                 MatchingFor("GM8E01_00", "GM8E01_01"),
                 "MetroidPrime/Tweaks/CTweakPlayerControl.cpp",
             ),
-            Object(MatchingFor("GM8E01_00", "GM8E01_01"), "MetroidPrime/Tweaks/CTweakPlayerGun.cpp"),
+            Object(
+                MatchingFor("GM8E01_00", "GM8E01_01"),
+                "MetroidPrime/Tweaks/CTweakPlayerGun.cpp",
+                cflags=cflags_retro,
+            ),
             Object(MatchingFor("GM8E01_00", "GM8E01_01"), "MetroidPrime/CPauseScreen.cpp"),
             Object(MatchingFor("GM8E01_00", "GM8E01_01"), "MetroidPrime/Tweaks/CTweakGui.cpp"),
             Object(
@@ -603,7 +615,11 @@ config.libs = [
                 MatchingFor("GM8E01_00", "GM8E01_01"),
                 "MetroidPrime/Tweaks/CTweakBall.cpp",
             ),
-            Object(NonMatching, "MetroidPrime/Player/CPlayerState.cpp"),
+            Object(
+                NonMatching,
+                "MetroidPrime/Player/CPlayerState.cpp",
+                cflags=cflags_retro,
+            ),
             Object(
                 MatchingFor("GM8E01_00", "GM8E01_01"),
                 "MetroidPrime/ScriptObjects/CScriptTimer.cpp",
@@ -649,9 +665,17 @@ config.libs = [
                 "MetroidPrime/CParticleGenInfo.cpp",
             ),
             Object(NonMatching, "MetroidPrime/CParticleDatabase.cpp"),
-            Object(MatchingFor("GM8E01_00", "GM8E01_01"), "MetroidPrime/Tweaks/CTweakGunRes.cpp"),
+            Object(
+                MatchingFor("GM8E01_00", "GM8E01_01"),
+                "MetroidPrime/Tweaks/CTweakGunRes.cpp",
+                cflags=cflags_retro,
+            ),
             Object(NonMatching, "MetroidPrime/CTargetReticles.cpp"),
-            Object(NonMatching, "MetroidPrime/CWeaponMgr.cpp"),
+            Object(
+                NonMatching,
+                "MetroidPrime/CWeaponMgr.cpp",
+                cflags=cflags_retro,
+            ),
             Object(
                 MatchingFor("GM8E01_00", "GM8E01_01"),
                 "MetroidPrime/ScriptObjects/CScriptPickup.cpp",
@@ -772,7 +796,12 @@ config.libs = [
             Object(
                 MatchingFor("GM8E01_00", "GM8E01_01", "GM8P01_00"), "MetroidPrime/CFluidUVMotion.cpp"
             ),
-            Object(MatchingFor("GM8E01_00"), "MetroidPrime/CRippleManager.cpp"),
+            Object(
+                MatchingFor("GM8E01_00"),
+                "MetroidPrime/CRippleManager.cpp",
+                # TODO: inline ripple fill at the common limit.
+                extra_cflags=['-pragma "inline_max_size(260)"'],
+            ),
             Object(NonMatching, "MetroidPrime/Player/CGrappleArm.cpp"),
             Object(NonMatching, "MetroidPrime/Enemies/CSpacePirate.cpp"),
             Object(
@@ -821,7 +850,11 @@ config.libs = [
                 "MetroidPrime/BodyState/CBSStep.cpp",
             ),
             Object(MatchingFor("GM8E01_00", "GM8E01_01"), "MetroidPrime/BodyState/CBSTurn.cpp"),
-            Object(MatchingFor("GM8E01_00"), "MetroidPrime/BodyState/CBodyController.cpp"),
+            Object(
+                MatchingFor("GM8E01_00"),
+                "MetroidPrime/BodyState/CBodyController.cpp",
+                cflags=cflags_retro,
+            ),
             Object(
                 MatchingFor("GM8E01_00", "GM8E01_01"),
                 "MetroidPrime/BodyState/CBSLoopAttack.cpp",
@@ -908,6 +941,7 @@ config.libs = [
             Object(
                 MatchingFor("GM8E01_00", "GM8E01_01"),
                 "MetroidPrime/Factories/CScannableObjectInfo.cpp",
+                cflags=cflags_retro,
             ),
             Object(MatchingFor("GM8E01_00", "GM8E01_01"), "MetroidPrime/Enemies/CMetroid.cpp"),
             Object(MatchingFor("GM8E01_00", "GM8E01_01"), "MetroidPrime/Player/CScanDisplay.cpp"),
@@ -930,7 +964,9 @@ config.libs = [
             Object(NonMatching, "MetroidPrime/Player/CPlayerOrbit.cpp"),
             Object(NonMatching, "MetroidPrime/CGameCollision.cpp"),
             Object(
-                MatchingFor("GM8E01_00", "GM8E01_01"), "MetroidPrime/CBallFilter.cpp"
+                MatchingFor("GM8E01_00", "GM8E01_01"),
+                "MetroidPrime/CBallFilter.cpp",
+                cflags=cflags_retro,
             ),
             Object(
                 MatchingFor("GM8E01_00", "GM8E01_01"), "MetroidPrime/CAABoxFilter.cpp"
@@ -958,7 +994,11 @@ config.libs = [
             Object(NonMatching, "MetroidPrime/Weapons/CFlameThrower.cpp"),
             Object(MatchingFor("GM8E01_00"), "MetroidPrime/Weapons/CBeamProjectile.cpp"),
             Object(NonMatching, "MetroidPrime/CFluidPlaneCPU.cpp"),
-            Object(NonMatching, "MetroidPrime/CFluidPlaneDoor.cpp"),
+            Object(
+                NonMatching,
+                "MetroidPrime/CFluidPlaneDoor.cpp",
+                cflags=cflags_retro,
+            ),
             Object(
                 MatchingFor("GM8E01_00", "GM8E01_01"),
                 "MetroidPrime/ScriptObjects/CScriptRoomAcoustics.cpp",
@@ -1086,7 +1126,11 @@ config.libs = [
             ),
             Object(MatchingFor("GM8E01_00"), "MetroidPrime/CWorldTransManager.cpp"),
             Object(NonMatching, "MetroidPrime/ScriptObjects/CScriptMidi.cpp"),
-            Object(NonMatching, "MetroidPrime/ScriptObjects/CScriptStreamedMusic.cpp"),
+            Object(
+                NonMatching,
+                "MetroidPrime/ScriptObjects/CScriptStreamedMusic.cpp",
+                cflags=cflags_retro,
+            ),
             Object(NonMatching, "MetroidPrime/CRagDoll.cpp"),
             Object(MatchingFor("GM8E01_00", "GM8E01_01"), "MetroidPrime/Player/CGameOptions.cpp"),
             Object(
@@ -1094,13 +1138,21 @@ config.libs = [
                 "MetroidPrime/ScriptObjects/CRepulsor.cpp",
             ),
             Object(NonMatching, "MetroidPrime/CEnvFxManager.cpp"),
-            Object(MatchingFor("GM8E01_00", "GM8E01_01"), "MetroidPrime/Weapons/CEnergyProjectile.cpp"),
+            Object(
+                MatchingFor("GM8E01_00", "GM8E01_01"),
+                "MetroidPrime/Weapons/CEnergyProjectile.cpp",
+                cflags=cflags_retro,
+            ),
             Object(NonMatching, "MetroidPrime/ScriptObjects/CScriptGunTurret.cpp"),
             Object(
                 MatchingFor("GM8E01_00", "GM8E01_01"),
                 "MetroidPrime/Weapons/CProjectileInfo.cpp",
             ),
-            Object(NonMatching, "MetroidPrime/CInGameTweakManager.cpp"),
+            Object(
+                NonMatching,
+                "MetroidPrime/CInGameTweakManager.cpp",
+                cflags=cflags_retro,
+            ),
             Object(NonMatching, "MetroidPrime/Enemies/CBabygoth.cpp"),
             Object(NonMatching, "MetroidPrime/Enemies/CEyeBall.cpp"),
             Object(
@@ -1188,6 +1240,7 @@ config.libs = [
             Object(
                 MatchingFor("GM8E01_00", "GM8E01_01"),
                 "MetroidPrime/CWorldSaveGameInfo.cpp",
+                cflags=cflags_retro,
             ),
             Object(NonMatching, "MetroidPrime/CFluidPlaneRender.cpp"),
             Object(MatchingFor("GM8E01_00", "GM8E01_01"), "MetroidPrime/Enemies/CBurrower.cpp"),
@@ -1259,7 +1312,11 @@ config.libs = [
             Object(NonMatching, "WorldFormat/CMetroidAreaCollider.cpp"),
             Object(MatchingFor("GM8E01_00", "GM8E01_01"), "WorldFormat/CWorldLight.cpp"),
             Object(MatchingFor("GM8E01_00", "GM8E01_01"), "WorldFormat/COBBTree.cpp"),
-            Object(NonMatching, "WorldFormat/CCollidableOBBTree.cpp"),
+            Object(
+                NonMatching,
+                "WorldFormat/CCollidableOBBTree.cpp",
+                cflags=cflags_retro,
+            ),
             Object(
                 MatchingFor("GM8E01_00", "GM8E01_01"), "WorldFormat/CCollidableOBBTreeGroup.cpp"
             ),
@@ -1342,7 +1399,9 @@ config.libs = [
                 "Collision/CCollidableCollisionSurface.cpp",
             ),
             Object(
-                MatchingFor("GM8E01_00", "GM8E01_01", "GM8P01_00"), "Collision/CCollisionInfo.cpp"
+                MatchingFor("GM8E01_00", "GM8E01_01", "GM8P01_00"),
+                "Collision/CCollisionInfo.cpp",
+                cflags=cflags_retro,
             ),
             Object(
                 MatchingFor("GM8E01_00", "GM8E01_01", "GM8P01_00"), "Collision/InternalColliders.cpp"
@@ -1359,7 +1418,11 @@ config.libs = [
             Object(
                 MatchingFor("GM8E01_00", "GM8E01_01", "GM8E01_48"), "Collision/CMaterialFilter.cpp"
             ),
-            Object(NonMatching, "Collision/COBBox.cpp"),
+            Object(
+                NonMatching,
+                "Collision/COBBox.cpp",
+                cflags=cflags_retro,
+            ),
             Object(MatchingFor("GM8E01_00", "GM8E01_01", "GM8P01_00"), "Collision/CMRay.cpp"),
         ],
     ),
@@ -1446,7 +1509,15 @@ config.libs = [
             Object(MatchingFor("GM8E01_00", "GM8E01_01"), "Kyoto/Animation/CTreeUtils.cpp"),
             Object(MatchingFor("GM8E01_00", "GM8E01_01"), "Kyoto/Animation/IMetaAnim.cpp"),
             Object(MatchingFor("GM8E01_00", "GM8E01_01"), "Kyoto/Audio/CSfxHandle.cpp"),
-            Object(MatchingFor("GM8E01_00", "GM8E01_01"), "Kyoto/Audio/CSfxManager.cpp"),
+            Object(
+                MatchingFor("GM8E01_00", "GM8E01_01"),
+                "Kyoto/Audio/CSfxManager.cpp",
+                extra_cflags=(
+                    ['-pragma "inline_max_size(140)"']
+                    if version_num == 4
+                    else []
+                ),
+            ),
             Object(MatchingFor("GM8E01_00", "GM8E01_01"), "Kyoto/Animation/CAdvancementDeltas.cpp"),
             Object(MatchingFor("GM8E01_00", "GM8E01_01", "GM8P01_00"), "Kyoto/Animation/CAnimMathUtils.cpp"),
             Object(MatchingFor("GM8E01_00", "GM8E01_01"), "Kyoto/Animation/CAnimPerSegmentData.cpp"),
@@ -1561,7 +1632,15 @@ config.libs = [
                 MatchingFor("GM8E01_00", "GM8E01_01"),
                 "Kyoto/Graphics/CTevCombiners.cpp",
             ),
-            Object(NonMatching, "Kyoto/Graphics/DolphinCGraphics.cpp"),
+            Object(
+                NonMatching,
+                "Kyoto/Graphics/DolphinCGraphics.cpp",
+                extra_cflags=(
+                    ['-pragma "inline_max_size(100)"']
+                    if version_num == 4
+                    else []
+                ),
+            ),
             Object(
                 MatchingFor("GM8E01_00", "GM8E01_01"),
                 "Kyoto/Graphics/DolphinCPalette.cpp",
@@ -1630,7 +1709,15 @@ config.libs = [
             Object(MatchingFor("GM8E01_00", "GM8E01_01", "GM8E01_48", "GM8P01_00"), "Kyoto/Particles/CWarp.cpp"),
             Object(MatchingFor("GM8E01_00", "GM8E01_01", "GM8E01_48", "GM8P01_00"), "Kyoto/Math/CPlane.cpp"),
             Object(MatchingFor("GM8E01_00", "GM8E01_01", "GM8E01_48", "GM8P01_00"), "Kyoto/Math/CSphere.cpp"),
-            Object(MatchingFor("GM8E01_00", "GM8E01_01", "GM8E01_48"), "Kyoto/Math/CAABox.cpp"),
+            Object(
+                MatchingFor("GM8E01_00", "GM8E01_01", "GM8E01_48"),
+                "Kyoto/Math/CAABox.cpp",
+                extra_cflags=(
+                    ['-pragma "inline_max_size(140)"']
+                    if version_num >= 4
+                    else []
+                ),
+            ),
             Object(NonMatching, "Kyoto/CFactoryMgr.cpp"),
             Object(NonMatching, "Kyoto/CResFactory.cpp"),
             Object(NonMatching, "Kyoto/CResLoader.cpp"),
@@ -1782,7 +1869,12 @@ config.libs = [
                 "Kyoto/Alloc/CSmallAllocPool.cpp",
             ),
             Object(NonMatching, "Kyoto/Alloc/CGameAllocator.cpp"),
-            Object(NonMatching, "Kyoto/Animation/DolphinCSkinnedModel.cpp"),
+            Object(
+                NonMatching,
+                "Kyoto/Animation/DolphinCSkinnedModel.cpp",
+                # TODO: inline optional assignment in AddSkinnedRef at the common limit.
+                extra_cflags=['-pragma "inline_max_size(259)"'],
+            ),
             Object(NonMatching, "Kyoto/Animation/DolphinCSkinRules.cpp"),
             Object(NonMatching, "Kyoto/Animation/DolphinCVirtualBone.cpp"),
             Object(NonMatching, "Kyoto/Graphics/DolphinCModel.cpp"),

--- a/src/Collision/CollisionUtil.cpp
+++ b/src/Collision/CollisionUtil.cpp
@@ -16,8 +16,6 @@
 #include "Kyoto/Math/CloseEnough.hpp"
 #include "rstl/math.hpp"
 
-#pragma inline_max_size(250)
-
 static inline float float_min(float a, float b) { return a < b ? a : b; }
 
 static inline float float_max(float a, float b) { return a > b ? a : b; }

--- a/src/Kyoto/Animation/CAnimCharacterSet.cpp
+++ b/src/Kyoto/Animation/CAnimCharacterSet.cpp
@@ -2,7 +2,6 @@
 #include "Kyoto/CFactoryFnReturn.hpp"
 #include "Kyoto/Streams/CInputStream.hpp"
 
-#pragma inline_max_size(240)
 CAnimCharacterSet::CAnimCharacterSet(CInputStream& in)
 : mVersion(in.Get< short >()), mCharacterSet(in), mAnimationSet(in) {}
 

--- a/src/Kyoto/Animation/CAnimPOIData.cpp
+++ b/src/Kyoto/Animation/CAnimPOIData.cpp
@@ -8,8 +8,6 @@
 #include "dolphin/types.h"
 #include "rstl/vector.hpp"
 
-#pragma inline_max_size(250)
-
 CAnimPOIData::CAnimPOIData(CInputStream& in)
 : mVersion(in.Get< uint >()), mBoolNodes(in), mInt32Nodes(in), mParticleNodes(in) {
   if (mVersion > 1) {

--- a/src/Kyoto/Animation/CAnimationSet.cpp
+++ b/src/Kyoto/Animation/CAnimationSet.cpp
@@ -1,7 +1,6 @@
 #include "Kyoto/Animation/CAnimationSet.hpp"
 #include "Kyoto/Animation/CMetaTransFactory.hpp"
 
-#pragma inline_max_size(240)
 CAnimationSet::CAnimationSet(CInputStream& in)
 : mTableCount(in.Get< short >())
 , mAnimations(in)

--- a/src/Kyoto/Animation/CSegIdList.cpp
+++ b/src/Kyoto/Animation/CSegIdList.cpp
@@ -3,9 +3,6 @@
 #include "Kyoto/Animation/CCharAnimMemoryMetrics.hpp"
 #include "Kyoto/Streams/CInputStream.hpp"
 
-/* this is such a hack... */
-#pragma inline_max_size(200)
-
 CSegIdList::CSegIdList(CInputStream& in)
 : mSegIds(in) {
   CCharAnimMemoryMetrics::AddToTotalSize(mSegIds.capacity(), CCharAnimMemoryMetrics::kASS_Two);  

--- a/src/Kyoto/Animation/CSkinnedModelWithAvgNormals.cpp
+++ b/src/Kyoto/Animation/CSkinnedModelWithAvgNormals.cpp
@@ -8,8 +8,6 @@
 #include "rstl/pair.hpp"
 #include "rstl/vector.hpp"
 
-#pragma inline_max_size(250)
-
 typedef rstl::pair< CVector3f, rstl::list< uint > > TPosToVertListPair;
 
 CSkinnedModelWithAvgNormals::CSkinnedModelWithAvgNormals(const CSkinnedModel& skinnedModel)

--- a/src/Kyoto/Animation/DolphinCSkinRules.cpp
+++ b/src/Kyoto/Animation/DolphinCSkinRules.cpp
@@ -5,8 +5,6 @@
 #include "dolphin/os/OSCache.h"
 #include "rstl/math.hpp"
 
-#pragma inline_max_size(250)
-
 static int StreamFloatToShort(CInputStream& in) {
   const int result = in.Get< int >();
   if (result == -1) {

--- a/src/Kyoto/Animation/DolphinCSkinnedModel.cpp
+++ b/src/Kyoto/Animation/DolphinCSkinnedModel.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(259) // TODO: adjusted from 250 for Skinning::AddSkinnedRef
-
 #include "Kyoto/Animation/CSkinnedModel.hpp"
 
 #include "Kyoto/Alloc/CCircularBuffer.hpp"

--- a/src/Kyoto/Audio/CMidiManager.cpp
+++ b/src/Kyoto/Audio/CMidiManager.cpp
@@ -122,7 +122,6 @@ CMidiManager::CMidiData::CMidiData(CInputStream& in)
   in.Get(x8_data.get(), len);
 }
 
-#pragma inline_max_size(250)
 const CFactoryFnReturn FMidiDataFactory(const SObjectTag& tag, CInputStream& in, const CVParamTransfer&) {
   return rs_new CMidiManager::CMidiData(in);
 }

--- a/src/Kyoto/Audio/CSfxManager.cpp
+++ b/src/Kyoto/Audio/CSfxManager.cpp
@@ -11,9 +11,6 @@
 #include "types.h"
 #include <Kyoto/Audio/CSfxManager.hpp>
 
-#if VERSION == 4
-#pragma inline_max_size(140)
-#endif
 float CSfxManager::mReverbAmount = 1.f;
 float CSfxManager::mReverbScale = 0.1f;
 CSfxManager::EAuxEffect CSfxManager::mCurrentAuxEffect = kAE_None;

--- a/src/Kyoto/CResLoader.cpp
+++ b/src/Kyoto/CResLoader.cpp
@@ -4,7 +4,6 @@
 #include "Kyoto/Streams/CZipInputStream.hpp"
 #include "rstl/StringExtras.hpp"
 
-#pragma inline_max_size(240)
 static inline int align_size(const int size) { return (size + 31) & ~31; }
 
 CResLoader::CResLoader()

--- a/src/Kyoto/Graphics/DolphinCGraphics.cpp
+++ b/src/Kyoto/Graphics/DolphinCGraphics.cpp
@@ -16,9 +16,6 @@
 
 #include <string.h>
 
-#if VERSION == 4 // JP
-#pragma inline_max_size(100)
-#endif
 bool CGraphicsSys::mGraphicsInitialized;
 static CStopwatch sFPSTimer;
 static uchar sSpareFrameBuffer[640 * 448] ATTRIBUTE_ALIGN(32);

--- a/src/Kyoto/Graphics/DolphinCModel.cpp
+++ b/src/Kyoto/Graphics/DolphinCModel.cpp
@@ -15,8 +15,6 @@
 #include <Kyoto/Graphics/CGraphics.hpp>
 #include <Kyoto/IObjectStore.hpp>
 #include <Kyoto/TToken.hpp>
-#pragma inline_max_size(250)
-
 static bool sIsTextureTimeoutEnabled = true;
 uint CModel::sTotalMemory = 0;
 CModel* CModel::sThisFrameList = nullptr;

--- a/src/Kyoto/Math/CAABox.cpp
+++ b/src/Kyoto/Math/CAABox.cpp
@@ -8,10 +8,6 @@
 
 #include "float.h"
 
-#if VERSION >= 4
-#pragma inline_max_size(140)
-#endif
-
 CAABox CAABox::mskInvertedBox(FLT_MAX, FLT_MAX, FLT_MAX, -FLT_MAX, -FLT_MAX, -FLT_MAX);
 CAABox CAABox::mskNullBox(0.f, 0.f, 0.f, 0.f, 0.f, 0.f);
 

--- a/src/Kyoto/Particles/CParticleSwoosh.cpp
+++ b/src/Kyoto/Particles/CParticleSwoosh.cpp
@@ -15,7 +15,6 @@
 #include "rstl/math.hpp"
 #include "rstl/reserved_vector.hpp"
 
-#pragma inline_max_size(250)
 uint CParticleSwoosh::mSwooshAliveCount = 0;
 static float kFrameTime = 1.f / 60.f;
 

--- a/src/Kyoto/Text/CStringTable.cpp
+++ b/src/Kyoto/Text/CStringTable.cpp
@@ -42,7 +42,6 @@ const wchar_t* CStringTable::GetString(int idx) const {
   return reinterpret_cast< const wchar_t* >(x4_data.get() + offset);
 }
 
-#pragma inline_max_size(250)
 const CFactoryFnReturn FStringTableFactory(const SObjectTag& tag, CInputStream& in,
                                      const CVParamTransfer& xfer) {
   return rs_new CStringTable(in);

--- a/src/MetaRender/CCubeRenderer.cpp
+++ b/src/MetaRender/CCubeRenderer.cpp
@@ -51,8 +51,6 @@
 #include <string.h>
 #include <type_traits>
 
-#pragma inline_max_size(250)
-
 CCubeRenderer* CCubeRenderer::sRenderer = nullptr;
 static CModelFlags skNormalFlag = CModelFlags::Normal();
 static CModelFlags skNormalFlagNoUpdate = CModelFlags::Normal().DepthCompareUpdate(true, false);

--- a/src/MetroidPrime/BodyState/CBodyStateInfo.cpp
+++ b/src/MetroidPrime/BodyState/CBodyStateInfo.cpp
@@ -34,8 +34,6 @@
 #include "Kyoto/Animation/CPASDatabase.hpp"
 #include "Kyoto/Math/CloseEnough.hpp"
 
-#pragma inline_max_size(250)
-
 CBodyStateInfo::CBodyStateInfo(CActor& actor, EBodyType type)
 : x14_state(pas::kAS_Invalid)
 , x18_bodyController(nullptr)

--- a/src/MetroidPrime/CActor.cpp
+++ b/src/MetroidPrime/CActor.cpp
@@ -25,7 +25,6 @@
 #include "MetroidPrime/TGameTypes.hpp"
 #include "rstl/math.hpp"
 
-#pragma inline_max_size(250)
 static CMaterialList MakeActorMaterialList(const CMaterialList& in,
                                            const CActorParameters& params) {
   CMaterialList ret = in;

--- a/src/MetroidPrime/CActorLights.cpp
+++ b/src/MetroidPrime/CActorLights.cpp
@@ -25,8 +25,6 @@
 #include <alloca.h>
 #include <float.h>
 
-#pragma inline_max_size(250)
-
 const float CActorLights::kDefaultPositionUpdateThreshold = 0.1f;
 const int CActorLights::kInvalidShadowLightIndex = -1;
 int CActorLights::sFrameSchedulerCount = 0;

--- a/src/MetroidPrime/CActorModelParticles.cpp
+++ b/src/MetroidPrime/CActorModelParticles.cpp
@@ -18,8 +18,6 @@
 #include "MetroidPrime/Enemies/CPatterned.hpp"
 #include "MetroidPrime/SFX/Misc.h"
 
-#pragma inline_max_size(250)
-
 static const char* const skParticleNames[] = {
     "Effect_OnFire",  "Effect_IceBreak", "Effect_Ash",
     "Effect_FirePop", "Effect_Electric", "Effect_IcePop",

--- a/src/MetroidPrime/CActorParameters.cpp
+++ b/src/MetroidPrime/CActorParameters.cpp
@@ -2,8 +2,6 @@
 
 #include "MetroidPrime/CActorLights.hpp"
 
-#pragma inline_max_size(250)
-
 CActorParameters::CActorParameters()
 : x0_lighting(CLightParameters::None())
 , x40_scannable(kInvalidAssetId)

--- a/src/MetroidPrime/CAnimData.cpp
+++ b/src/MetroidPrime/CAnimData.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CAnimData.hpp"
 
 #include "Kyoto/Animation/CAnimTreeBlend.hpp"

--- a/src/MetroidPrime/CArtifactDoll.cpp
+++ b/src/MetroidPrime/CArtifactDoll.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CArtifactDoll.hpp"
 #include "Kyoto/CSimplePool.hpp"
 #include "Kyoto/Graphics/CModel.hpp"

--- a/src/MetroidPrime/CAutoMapper.cpp
+++ b/src/MetroidPrime/CAutoMapper.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CAutoMapper.hpp"
 #include "rstl/math.hpp"
 

--- a/src/MetroidPrime/CCollisionActor.cpp
+++ b/src/MetroidPrime/CCollisionActor.cpp
@@ -14,8 +14,6 @@
 
 #include "rstl/math.hpp"
 
-#pragma inline_max_size(250)
-
 static const CMaterialList gkDefaultCollisionActorMaterials(kMT_Solid, kMT_CollisionActor,
                                                             kMT_ScanPassthrough,
                                                             kMT_CameraPassthrough);

--- a/src/MetroidPrime/CCollisionActorManager.cpp
+++ b/src/MetroidPrime/CCollisionActorManager.cpp
@@ -11,8 +11,6 @@
 #include "MetroidPrime/TCastTo.hpp"
 #include <float.h>
 
-#pragma inline_max_size(250)
-
 CJointCollisionDescription CJointCollisionDescription::SphereCollision(CSegId pivotId, float radius,
                                                                        const rstl::string& name,
                                                                        float mass) {

--- a/src/MetroidPrime/CCredits.cpp
+++ b/src/MetroidPrime/CCredits.cpp
@@ -29,8 +29,6 @@
 #include "rstl/StringExtras.hpp"
 #include "rstl/math.hpp"
 
-#pragma inline_max_size(250)
-
 static const char* const skMovieNames[] = {"Video/wingame.thp",       "Video/wingame_best.thp",
                                            "Video/wingame_best.thp",  "Video/losegame.thp",
                                            "Video/05_tallonText.thp", "Video/AfterCredits.thp",

--- a/src/MetroidPrime/CDecalManager.cpp
+++ b/src/MetroidPrime/CDecalManager.cpp
@@ -12,7 +12,6 @@ float CDecalManager::mDeltaTimeSinceLastDecalCreation;
 int CDecalManager::mLastDecalCreatedIndex;
 CAssetId CDecalManager::mLastDecalCreatedAssetId;
 
-#pragma inline_max_size(250)
 void CDecalManager::Initialize() {
   if (mbPoolInitialized) {
     return;

--- a/src/MetroidPrime/CEnvFxManager.cpp
+++ b/src/MetroidPrime/CEnvFxManager.cpp
@@ -34,8 +34,6 @@
 
 #include <float.h>
 
-#pragma inline_max_size(250)
-
 static const float gkReal32Max = FLT_MAX;
 static float g_SnowForces[256][2];
 

--- a/src/MetroidPrime/CFlameWarp.cpp
+++ b/src/MetroidPrime/CFlameWarp.cpp
@@ -9,8 +9,6 @@
 #include "rstl/algorithm.hpp"
 #include "rstl/vector.hpp"
 
-#pragma inline_max_size(250)
-
 static EMaterialTypes ProjectilePassthroughMaterial = kMT_ProjectilePassthrough;
 
 // Particle fields are interleaved with a caller-supplied byte stride.

--- a/src/MetroidPrime/CFluidPlaneCPU.cpp
+++ b/src/MetroidPrime/CFluidPlaneCPU.cpp
@@ -36,8 +36,6 @@
 
 #include <math.h>
 
-#pragma inline_max_size(250)
-
 float* InitializeSineWave();
 
 static int kMaxTilesInHField = 7;

--- a/src/MetroidPrime/CFrontEndUI.cpp
+++ b/src/MetroidPrime/CFrontEndUI.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CFrontEndUI.hpp"
 
 #include "Kyoto/Audio/CAudioGroupSet.hpp"

--- a/src/MetroidPrime/CGameArea.cpp
+++ b/src/MetroidPrime/CGameArea.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CGameArea.hpp"
 
 #include "MetroidPrime/CMemoryDrawEnum.hpp"

--- a/src/MetroidPrime/CGameCollision.cpp
+++ b/src/MetroidPrime/CGameCollision.cpp
@@ -27,8 +27,6 @@
 #include <Collision/CRayCastResult.hpp>
 #include <WorldFormat/CCollidableOBBTreeGroup.hpp>
 
-#pragma inline_max_size(250)
-
 static int gDebugPrintCount;
 
 void CGameCollision::InitCollision() {

--- a/src/MetroidPrime/CGameCubeDoll.cpp
+++ b/src/MetroidPrime/CGameCubeDoll.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CGameCubeDoll.hpp"
 
 #include "MetroidPrime/CActorLights.hpp"

--- a/src/MetroidPrime/CGameHintInfo.cpp
+++ b/src/MetroidPrime/CGameHintInfo.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CGameHintInfo.hpp"
 
 #include "MetroidPrime/CMemoryCard.hpp"

--- a/src/MetroidPrime/CGameLight.cpp
+++ b/src/MetroidPrime/CGameLight.cpp
@@ -2,8 +2,6 @@
 
 #include "MetroidPrime/CActorParameters.hpp"
 
-#pragma inline_max_size(250)
-
 CGameLight::CGameLight(TUniqueId uid, TAreaId aid, const bool active, const rstl::string& name,
                        const CTransform4f& xf, TUniqueId parentId, const CLight& light,
                        uint sourceId, uint priority, float lifeTime)

--- a/src/MetroidPrime/CGroundMovement.cpp
+++ b/src/MetroidPrime/CGroundMovement.cpp
@@ -20,8 +20,6 @@
 #include <float.h>
 #include <math.h>
 
-#pragma inline_max_size(250)
-
 void CGroundMovement::CheckFalling(CPhysicsActor& actor, CStateManager& mgr, float dt) {
   bool outOfBounds = true;
   const CAABox bounds = *actor.GetTouchBounds();

--- a/src/MetroidPrime/CIOWinManager.cpp
+++ b/src/MetroidPrime/CIOWinManager.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CIOWinManager.hpp"
 
 #include "MetroidPrime/CIOWin.hpp"

--- a/src/MetroidPrime/CIkChain.cpp
+++ b/src/MetroidPrime/CIkChain.cpp
@@ -6,8 +6,6 @@
 #include "Kyoto/Math/CRelAngle.hpp"
 #include "Kyoto/Math/CUnitVector3f.hpp"
 
-#pragma inline_max_size(250)
-
 void CIkChain::Solve(CQuaternion& q1, CQuaternion& q2, const CVector3f& pos) {
   const float mag = pos.Magnitude();
   float secondCos =

--- a/src/MetroidPrime/CInGameGuiManager.cpp
+++ b/src/MetroidPrime/CInGameGuiManager.cpp
@@ -1,7 +1,5 @@
 #include "MetroidPrime/CInGameGuiManager.hpp"
 
-#pragma inline_max_size(250)
-
 #include "Kyoto/Audio/CSfxManager.hpp"
 #include "Kyoto/CFrameDelayedKiller.hpp"
 #include "Kyoto/Graphics/CModel.hpp"

--- a/src/MetroidPrime/CLogBookScreen.cpp
+++ b/src/MetroidPrime/CLogBookScreen.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CLogBookScreen.hpp"
 
 #include "GuiSys/CAuiImagePane.hpp"

--- a/src/MetroidPrime/CMFGame.cpp
+++ b/src/MetroidPrime/CMFGame.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CMFGame.hpp"
 #include "Kyoto/CResFactory.hpp"
 #include "Kyoto/CSimplePool.hpp"

--- a/src/MetroidPrime/CMainFlow.cpp
+++ b/src/MetroidPrime/CMainFlow.cpp
@@ -64,7 +64,6 @@ static inline bool IsCreditsMode(CMain::ERestartMode m) {
   return m >= CMain::kRM_WinBad && m <= CMain::kRM_LoseGame;
 }
 
-#pragma inline_max_size(250)
 void CMainFlow::SetGameState(EClientFlowStates state, CArchitectureQueue& queue) {
   x14_gameState = state;
 

--- a/src/MetroidPrime/CMapUniverse.cpp
+++ b/src/MetroidPrime/CMapUniverse.cpp
@@ -11,8 +11,6 @@
 #include "rstl/math.hpp"
 #include "rstl/rc_ptr.hpp"
 
-#pragma inline_max_size(250)
-
 class CMapObjectSortInfoGreaterThan {
 public:
   bool operator()(const CMapUniverse::CMapObjectSortInfo& a,

--- a/src/MetroidPrime/CMapWorld.cpp
+++ b/src/MetroidPrime/CMapWorld.cpp
@@ -20,8 +20,6 @@
 #include <math.h>
 #include <stdlib.h>
 
-#pragma inline_max_size(250)
-
 struct CMapObjectSortInfoGreaterThan {
   CMapObjectSortInfoGreaterThan() {}
   bool operator()(const CMapWorld::CMapObjectSortInfo& a,

--- a/src/MetroidPrime/CMapWorldInfo.cpp
+++ b/src/MetroidPrime/CMapWorldInfo.cpp
@@ -7,8 +7,6 @@
 #include "Kyoto/Streams/COutputStream.hpp"
 #include "rstl/algorithm.hpp"
 
-#pragma inline_max_size(250)
-
 CMapWorldInfo::CMapWorldInfo() : mMapStationUsed(false) {}
 
 CMapWorldInfo::CMapWorldInfo(CInputStream& in, const CWorldSaveGameInfo& saveInfo,

--- a/src/MetroidPrime/CMemoryCard.cpp
+++ b/src/MetroidPrime/CMemoryCard.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CMemoryCard.hpp"
 
 #include "MetroidPrime/CGameHintInfo.hpp"

--- a/src/MetroidPrime/CMemoryCardDriver.cpp
+++ b/src/MetroidPrime/CMemoryCardDriver.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CMemoryCardDriver.hpp"
 
 #include "MetroidPrime/CMain.hpp"

--- a/src/MetroidPrime/CParticleDatabase.cpp
+++ b/src/MetroidPrime/CParticleDatabase.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CParticleDatabase.hpp"
 
 #include "Kyoto/Animation/CCharLayoutInfo.hpp"

--- a/src/MetroidPrime/CPauseScreenFrame.cpp
+++ b/src/MetroidPrime/CPauseScreenFrame.cpp
@@ -1,4 +1,3 @@
-#pragma inline_max_size(250)
 #include "MetroidPrime/COptionsScreen.hpp"
 #include "MetroidPrime/CQuitGameScreen.hpp"
 #include "MetroidPrime/SOptionsFrontEndFrame.hpp"

--- a/src/MetroidPrime/CProjectedShadow.cpp
+++ b/src/MetroidPrime/CProjectedShadow.cpp
@@ -16,8 +16,6 @@
 #include <dolphin/gx.h>
 #include <float.h>
 
-#pragma inline_max_size(250)
-
 struct SShadowDrawContext {
   const CSkinnedModel& model;
   bool drawAll;

--- a/src/MetroidPrime/CRagDoll.cpp
+++ b/src/MetroidPrime/CRagDoll.cpp
@@ -13,8 +13,6 @@
 
 #include <float.h>
 
-#pragma inline_max_size(250)
-
 CRagDoll::CRagDoll(float normalGravity, float floatingGravity, float overTime, uint flags)
 : x44_normalGravity(normalGravity)
 , x48_floatingGravity(floatingGravity)

--- a/src/MetroidPrime/CRainSplashGenerator.cpp
+++ b/src/MetroidPrime/CRainSplashGenerator.cpp
@@ -11,8 +11,6 @@
 
 #include "rstl/math.hpp"
 
-#pragma inline_max_size(250)
-
 const float CRainSplashGenerator::SSplashLine::skInitialSpeed = 4.f;
 const float CRainSplashGenerator::SSplashLine::skInitialHeight = 0.015625f;
 const uchar CRainSplashGenerator::SSplashLine::skInitialWidth = 3;

--- a/src/MetroidPrime/CRippleManager.cpp
+++ b/src/MetroidPrime/CRippleManager.cpp
@@ -5,8 +5,6 @@
 
 #include "rstl/math.hpp"
 
-#pragma inline_max_size(260)
-
 CRippleManager::CRippleManager(int maxRipples, float alpha)
 : x0_maxTimeFalloff(0.f)
 , x14_alpha(alpha) {

--- a/src/MetroidPrime/CSamusDoll.cpp
+++ b/src/MetroidPrime/CSamusDoll.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CSamusDoll.hpp"
 
 #include "MetroidPrime/CActorLights.hpp"

--- a/src/MetroidPrime/CScriptLayerManager.cpp
+++ b/src/MetroidPrime/CScriptLayerManager.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CScriptLayerManager.hpp"
 
 #include "Kyoto/Streams/CInputStream.hpp"

--- a/src/MetroidPrime/CSlideShow.cpp
+++ b/src/MetroidPrime/CSlideShow.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CSlideShow.hpp"
 #include "Kyoto/Text/CStringTable.hpp"
 #include "MetroidPrime/CArchMsgParmReal32.hpp"

--- a/src/MetroidPrime/CSplashScreen.cpp
+++ b/src/MetroidPrime/CSplashScreen.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CSplashScreen.hpp"
 
 #include "Kyoto/Graphics/CGraphics.hpp"

--- a/src/MetroidPrime/CStateManager.cpp
+++ b/src/MetroidPrime/CStateManager.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #define CSTATEMANAGER_OUT_OF_LINE_GETPLAYER
 #include "MetroidPrime/CStateManager.hpp"
 #undef CSTATEMANAGER_OUT_OF_LINE_GETPLAYER

--- a/src/MetroidPrime/CTargetReticles.cpp
+++ b/src/MetroidPrime/CTargetReticles.cpp
@@ -38,8 +38,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#pragma inline_max_size(250)
-
 static const char skCrosshairsReticleAssetName[] = "CMDL_Crosshairs";
 static const char skOrbitZoneReticleAssetName[] = "CMDL_OrbitZone";
 static const char skSeekerAssetName[] = "CMDL_Seeker";

--- a/src/MetroidPrime/CTransitionDatabaseGame.cpp
+++ b/src/MetroidPrime/CTransitionDatabaseGame.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CTransitionDatabaseGame.hpp"
 
 #include "Kyoto/Animation/CHalfTransition.hpp"

--- a/src/MetroidPrime/CVisorFlare.cpp
+++ b/src/MetroidPrime/CVisorFlare.cpp
@@ -23,8 +23,6 @@
 
 #include "math.h"
 
-#pragma inline_max_size(250)
-
 CVisorFlare::CFlareDef::CFlareDef(const TToken< CTexture >& tex, float pos, float scale, uint color)
 : x0_tex(tex), x8_pos(pos), xc_scale(scale), x10_color(color) {
   x0_tex.Lock();

--- a/src/MetroidPrime/CWorld.cpp
+++ b/src/MetroidPrime/CWorld.cpp
@@ -34,8 +34,6 @@
 CGameArea::CConstChainIterator CWorld::skGlobalEnd;
 CGameArea::CChainIterator CWorld::skGlobalNonConstEnd;
 
-#pragma inline_max_size(250)
-
 void CWorldLayers::ReadWorldLayers(CInputStream& in, int version, CAssetId mlvlId) {
   if (static_cast< uint >(version) > 14) {
     rstl::vector< Area > areas(in);

--- a/src/MetroidPrime/CWorldTransManager.cpp
+++ b/src/MetroidPrime/CWorldTransManager.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Player/CWorldTransManager.hpp"
 
 #include "GuiSys/CGuiTextSupport.hpp"

--- a/src/MetroidPrime/Cameras/CBallCamera.cpp
+++ b/src/MetroidPrime/Cameras/CBallCamera.cpp
@@ -29,8 +29,6 @@
 
 #include "math.h"
 
-#pragma inline_max_size(250)
-
 static CMaterialList kLineOfSightIncludeList = CMaterialList(kMT_Solid);
 static CMaterialList kLineOfSightExcludeList =
     CMaterialList(kMT_ProjectilePassthrough, kMT_Player, kMT_Character, kMT_CameraPassthrough);

--- a/src/MetroidPrime/Cameras/CBallCameraFailsafeState.cpp
+++ b/src/MetroidPrime/Cameras/CBallCameraFailsafeState.cpp
@@ -10,8 +10,6 @@
 #include "MetroidPrime/Player/CPlayer.hpp"
 #include "WorldFormat/CMetroidAreaCollider.hpp"
 
-#pragma inline_max_size(250)
-
 bool CBallCamera::CheckTransitionLineOfSight(const CVector3f& eyePos, const CVector3f& behindPos,
                                              float& eyeToOccDist, float colRadius,
                                              const CStateManager& mgr) {

--- a/src/MetroidPrime/Cameras/CCameraFilter.cpp
+++ b/src/MetroidPrime/Cameras/CCameraFilter.cpp
@@ -23,8 +23,6 @@
 #include "stdlib.h"
 #include "string.h"
 
-#pragma inline_max_size(250)
-
 static const char* const skDebugFilterTypeNames[] = {
     "PassThru   ", "Multiply   ", "Invert     ", "Add        ", "Subtract   ",
     "Blend      ", "WideScreen ", "SceneAdd   ", "NoColor    ",

--- a/src/MetroidPrime/Cameras/CCameraManager.cpp
+++ b/src/MetroidPrime/Cameras/CCameraManager.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Cameras/CCameraManager.hpp"
 
 #include "Kyoto/Math/CVector3f.hpp"

--- a/src/MetroidPrime/Cameras/CCinematicCamera.cpp
+++ b/src/MetroidPrime/Cameras/CCinematicCamera.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Cameras/CCinematicCamera.hpp"
 
 #include "MetroidPrime/CAnimData.hpp"

--- a/src/MetroidPrime/Cameras/CGameCamera.cpp
+++ b/src/MetroidPrime/Cameras/CGameCamera.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Cameras/CGameCamera.hpp"
 
 #include "Collision/CMaterialFilter.hpp"

--- a/src/MetroidPrime/Enemies/CBabygoth.cpp
+++ b/src/MetroidPrime/Enemies/CBabygoth.cpp
@@ -21,8 +21,6 @@
 #include "MetroidPrime/Weapons/CFlameThrower.hpp"
 #include "MetroidPrime/Weapons/CWeapon.hpp"
 
-#pragma inline_max_size(250)
-
 const int CBabygothData::skMinProperties = 33;
 
 const CVector3f CBabygoth::skAttackTouchBounds(0.2f, 0.2f, 0.2f);

--- a/src/MetroidPrime/Enemies/CBeetle.cpp
+++ b/src/MetroidPrime/Enemies/CBeetle.cpp
@@ -17,8 +17,6 @@
 
 #include "float.h"
 
-#pragma inline_max_size(250)
-
 static const char* const kBiteLctrName = "LCTR_GARMOUTH";
 static const char* const kDamageLctrName = "Target_Tail";
 static const char* const kBetaLctrName = "Target_Tail";

--- a/src/MetroidPrime/Enemies/CBurrower.cpp
+++ b/src/MetroidPrime/Enemies/CBurrower.cpp
@@ -11,8 +11,6 @@
 #include "MetroidPrime/TCastTo.hpp"
 #include "Kyoto/Particles/CElementGen.hpp"
 
-#pragma inline_max_size(250)
-
 const CDamageVulnerability CBurrower::skBombVulnerability =
     CDamageVulnerability(kVN_Deflect, kVN_Deflect, kVN_Deflect, kVN_Deflect, kVN_Normal, kVN_Normal,
                         kVN_Deflect, kVN_Deflect, kVN_Deflect, kVN_Deflect, kVN_Deflect,

--- a/src/MetroidPrime/Enemies/CDrone.cpp
+++ b/src/MetroidPrime/Enemies/CDrone.cpp
@@ -33,8 +33,6 @@
 #include "MetroidPrime/Player/CPlayerState.hpp"
 #include "rstl/math.hpp"
 
-#pragma inline_max_size(250)
-
 static const char* sBeaconLocator = "Beacon_LCTR";
 static const char* sRightGunLocator = "R_GUN_TOP_LCTR";
 static const char* sLeftGunLocator = "L_GUN_TOP_LCTR";

--- a/src/MetroidPrime/Enemies/CElitePirate.cpp
+++ b/src/MetroidPrime/Enemies/CElitePirate.cpp
@@ -24,8 +24,6 @@
 #include "rstl/algorithm.hpp"
 #include "rstl/math.hpp"
 
-#pragma inline_max_size(250)
-
 const int CElitePirateData::skMinProperties = 41;
 
 const CElitePirate::SJointInfo CElitePirate::skLeftArmJointList[3] = {

--- a/src/MetroidPrime/Enemies/CFlaahgra.cpp
+++ b/src/MetroidPrime/Enemies/CFlaahgra.cpp
@@ -30,8 +30,6 @@
 
 #include <float.h>
 
-#pragma inline_max_size(250)
-
 static const CVector3f skExtendedBounds(12.f, 12.f, 12.f);
 static const CVector3f skProjectileOffset(0.5f, 7.f, 0.f);
 static const CColor skFlaahgraDamageColor(0.5f, 0.5f, 0.f, 1.f);

--- a/src/MetroidPrime/Enemies/CFlaahgraTentacle.cpp
+++ b/src/MetroidPrime/Enemies/CFlaahgraTentacle.cpp
@@ -10,8 +10,6 @@
 #include "MetroidPrime/ScriptObjects/CScriptTrigger.hpp"
 #include "MetroidPrime/TCastTo.hpp"
 
-#pragma inline_max_size(250)
-
 const CFlaahgraTentacle::SSphereJointInfo CFlaahgraTentacle::skJointList[] = {
     {"Arm_8", 2.f},
     {"Arm_10", 1.2f},

--- a/src/MetroidPrime/Enemies/CFlyingPirate.cpp
+++ b/src/MetroidPrime/Enemies/CFlyingPirate.cpp
@@ -38,8 +38,6 @@
 #include "Kyoto/CSimplePool.hpp"
 #include "Kyoto/Particles/CGenDescription.hpp"
 
-#pragma inline_max_size(250)
-
 const SBurst CFlyingPirate::skBurstsFlying[] = {
     {10, {3, 4, 11, 12, -1, 0, 0, 0}, 0.1f, 0.05f},
     {20, {2, 3, 4, 5, -1, 0, 0, 0}, 0.1f, 0.05f},

--- a/src/MetroidPrime/Enemies/CGrenadeLauncher.cpp
+++ b/src/MetroidPrime/Enemies/CGrenadeLauncher.cpp
@@ -14,8 +14,6 @@
 #include "rstl/math.hpp"
 #include <float.h>
 
-#pragma inline_max_size(250)
-
 static const CMaterialList skLauncherMaterial(kMT_Character, kMT_Solid);
 static const int skLauncherAnims[] = {0, 3};
 static const char* const skGrenadeLocator = "grenade_LCTR";

--- a/src/MetroidPrime/Enemies/CIceSheegoth.cpp
+++ b/src/MetroidPrime/Enemies/CIceSheegoth.cpp
@@ -28,8 +28,6 @@
 #include "MetroidPrime/BodyState/CBodyState.hpp"
 #include "rstl/math.hpp"
 
-#pragma inline_max_size(250)
-
 const int CIceSheegothData::skNumProperties = 37;
 
 const CVector3f CIceSheegoth::skChargingBounds(2.f, 2.f, 2.f);

--- a/src/MetroidPrime/Enemies/CMagdolite.cpp
+++ b/src/MetroidPrime/Enemies/CMagdolite.cpp
@@ -18,8 +18,6 @@
 
 #include "float.h"
 
-#pragma inline_max_size(250)
-
 static const char* skMouthLocator = "LCTR_MAGMOUTH";
 static const char* skHeadLocator = "head";
 static const char* skHeadBone = "head";

--- a/src/MetroidPrime/Enemies/CMetroid.cpp
+++ b/src/MetroidPrime/Enemies/CMetroid.cpp
@@ -26,8 +26,6 @@
 #include "Kyoto/Animation/CPASAnimParmData.hpp"
 #include "Kyoto/Animation/CSegId.hpp"
 
-#pragma inline_max_size(250)
-
 static EMaterialTypes skSolidMaterial = kMT_Solid;
 
 const uint CMetroidData::skNumProperties = 20;

--- a/src/MetroidPrime/Enemies/CMetroidBeta.cpp
+++ b/src/MetroidPrime/Enemies/CMetroidBeta.cpp
@@ -22,8 +22,6 @@
 #include "MetroidPrime/TCastTo.hpp"
 #include "MetroidPrime/Weapons/CGameProjectile.hpp"
 
-#pragma inline_max_size(250)
-
 const uint CMetroidBetaData::skNumProperties = 23;
 
 static const SSphereJointInfo skSphereJoints[] = {{"Pelvis", 1.5f}};

--- a/src/MetroidPrime/Enemies/CMetroidPrime.cpp
+++ b/src/MetroidPrime/Enemies/CMetroidPrime.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/CWorld.hpp"
 #include "MetroidPrime/Enemies/CMetroidPrime.hpp"
 #include "Collision/CRayCastResult.hpp"

--- a/src/MetroidPrime/Enemies/CMetroidPrimeRelay.cpp
+++ b/src/MetroidPrime/Enemies/CMetroidPrimeRelay.cpp
@@ -6,8 +6,6 @@
 #include "Kyoto/Audio/CSfxManager.hpp"
 #include "Kyoto/Streams/CInputStream.hpp"
 
-#pragma inline_max_size(250)
-
 CCameraShakeData LoadAndBuildPrimeCameraShakeData(CInputStream& in);
 
 CMetroidPrimeIceAttack::CMetroidPrimeIceAttack(CInputStream& in)

--- a/src/MetroidPrime/Enemies/CMetroidPrimeStage2.cpp
+++ b/src/MetroidPrime/Enemies/CMetroidPrimeStage2.cpp
@@ -25,8 +25,6 @@
 #include "MetroidPrime/Weapons/CShockWave.hpp"
 #include "rstl/math.hpp"
 
-#pragma inline_max_size(250)
-
 static const int skVisorPhases[] = {0, 1, 0, 2};
 static const int skStepDirections[] = {1, 2, 3};
 static const char* const skLockOnTarget = "lockon_target_LCTR";

--- a/src/MetroidPrime/Enemies/CNewIntroBoss.cpp
+++ b/src/MetroidPrime/Enemies/CNewIntroBoss.cpp
@@ -1,7 +1,5 @@
 #include "MetroidPrime/Enemies/CNewIntroBoss.hpp"
 
-#pragma inline_max_size(250)
-
 #include "Kyoto/Animation/CPOINode.hpp"
 #include "MetroidPrime/CCollisionActorManager.hpp"
 #include "MetroidPrime/CGameCollision.hpp"

--- a/src/MetroidPrime/Enemies/COmegaPirate.cpp
+++ b/src/MetroidPrime/Enemies/COmegaPirate.cpp
@@ -29,8 +29,6 @@
 #include "MetroidPrime/ScriptObjects/CScriptSound.hpp"
 #include "MetroidPrime/Weapons/CGameProjectile.hpp"
 
-#pragma inline_max_size(250)
-
 const char* const COmegaPirate::skpGrenadeLauncher2LCTR = "grenadeLauncher2_LCTR";
 const SSphereJointInfo COmegaPirate::skSphereJointList[1] = {{"lockon_target_LCTR", 1.f}};
 const COmegaPirate::SOBBoxJointInfo COmegaPirate::skOBBJointList[11] = {

--- a/src/MetroidPrime/Enemies/CParasite.cpp
+++ b/src/MetroidPrime/Enemies/CParasite.cpp
@@ -25,8 +25,6 @@
 #include "MetroidPrime/ScriptObjects/CScriptWaypoint.hpp"
 #include "MetroidPrime/TCastTo.hpp"
 
-#pragma inline_max_size(250)
-
 static const SSphereJointInfo skIceJoints[] = {{"Ice_LCTR", 0.4f}};
 float CParasite::skAttackTime = 2.f * CMath::SqrtF(2.5f / CPhysicsActor::GravityConstant());
 float CParasite::skAttackVelocity = 15.f / skAttackTime;

--- a/src/MetroidPrime/Enemies/CPatterned.cpp
+++ b/src/MetroidPrime/Enemies/CPatterned.cpp
@@ -40,8 +40,6 @@
 #include "dolphin/gx/GXStruct.h"
 #include "dolphin/types.h"
 
-#pragma inline_max_size(250)
-
 const float CPatterned::skDamageHitTime = 0.33f;
 const float CPatterned::skActorApproachDistance = 3.f;
 

--- a/src/MetroidPrime/Enemies/CPuddleSpore.cpp
+++ b/src/MetroidPrime/Enemies/CPuddleSpore.cpp
@@ -13,7 +13,6 @@
 #include "MetroidPrime/TCastTo.hpp"
 #include "MetroidPrime/Weapons/CEnergyProjectile.hpp"
 
-#pragma inline_max_size(250)
 int CPuddleSpore::kEyeCount = 16;
 const char* CPuddleSpore::kEyeLocators[] = {
     "Glow_1_LCTR",  "Glow_2_LCTR",  "Glow_3_LCTR",  "Glow_4_LCTR",  "Glow_5_LCTR",  "Glow_6_LCTR",

--- a/src/MetroidPrime/Enemies/CPuddleToadGamma.cpp
+++ b/src/MetroidPrime/Enemies/CPuddleToadGamma.cpp
@@ -12,8 +12,6 @@
 #include "MetroidPrime/Weapons/CBomb.hpp"
 #include "MetroidPrime/Player/CPlayer.hpp"
 
-#pragma inline_max_size(250)
-
 const CVector3f CPuddleToadGamma::skBellyOffset(0.f, 0.1f, -0.3f);
 const char* CPuddleToadGamma::mMouthLocatorName = "MOUTH_LCTR_SDK";
 const char* CPuddleToadGamma::mBellyLocatorName = "SAMUS_POS_LCTR_SDK";

--- a/src/MetroidPrime/Enemies/CRidley.cpp
+++ b/src/MetroidPrime/Enemies/CRidley.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Enemies/CRidley.hpp"
 #include "Kyoto/Animation/CPASAnimParmData.hpp"
 #include "Kyoto/Audio/CSfxManager.hpp"

--- a/src/MetroidPrime/Enemies/CSnakeWeedSwarm.cpp
+++ b/src/MetroidPrime/Enemies/CSnakeWeedSwarm.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/ScriptObjects/CSnakeWeedSwarm.hpp"
 
 #include "Kyoto/Animation/CSkinnedModel.hpp"

--- a/src/MetroidPrime/Enemies/CSpacePirate.cpp
+++ b/src/MetroidPrime/Enemies/CSpacePirate.cpp
@@ -37,8 +37,6 @@
 #include "rstl/algorithm.hpp"
 #include <float.h>
 
-#pragma inline_max_size(250)
-
 static const rstl::string skParts[] = {
     rstl::string_l("Collar"),  rstl::string_l("Neck_1"),  rstl::string_l("R_shoulder"),
     rstl::string_l("R_elbow"), rstl::string_l("R_wrist"), rstl::string_l("L_shoulder"),

--- a/src/MetroidPrime/Enemies/CSpankWeed.cpp
+++ b/src/MetroidPrime/Enemies/CSpankWeed.cpp
@@ -7,8 +7,6 @@
 #include "MetroidPrime/CStateManager.hpp"
 #include "MetroidPrime/Player/CPlayer.hpp"
 
-#pragma inline_max_size(250)
-
 // These strings survive from the unused collision actor implementation.
 static const char* skJointNameList[] = {
     "Arm_2", "Arm_3",  "Arm_4",  "Arm_5",  "Arm_6",   "Arm_7",       "Arm_8",

--- a/src/MetroidPrime/Enemies/CTeamAiMgr.cpp
+++ b/src/MetroidPrime/Enemies/CTeamAiMgr.cpp
@@ -7,8 +7,6 @@
 #include "MetroidPrime/TCastTo.hpp"
 #include "rstl/algorithm.hpp"
 
-#pragma inline_max_size(250)
-
 const int CTeamAiMgr::CUnknown::kNumProperties = 8;
 
 struct CRoleSorter {

--- a/src/MetroidPrime/Enemies/CThardus.cpp
+++ b/src/MetroidPrime/Enemies/CThardus.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Enemies/CThardus.hpp"
 
 #include "Collision/CRayCastResult.hpp"

--- a/src/MetroidPrime/Enemies/CThardusRockProjectile.cpp
+++ b/src/MetroidPrime/Enemies/CThardusRockProjectile.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Enemies/CThardusRockProjectile.hpp"
 
 #include "Collision/CRayCastResult.hpp"

--- a/src/MetroidPrime/Enemies/CWallCrawlerSwarm.cpp
+++ b/src/MetroidPrime/Enemies/CWallCrawlerSwarm.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Enemies/CWallCrawlerSwarm.hpp"
 
 #include "Collision/CCollidableSphere.hpp"

--- a/src/MetroidPrime/Enemies/CWallWalker.cpp
+++ b/src/MetroidPrime/Enemies/CWallWalker.cpp
@@ -12,8 +12,6 @@
 #include "MetroidPrime/TCastTo.hpp"
 #include "WorldFormat/CMetroidAreaCollider.hpp"
 
-#pragma inline_max_size(250)
-
 static const char* const skBendingAnimation = "BendingAnimationHack";
 
 CWallWalker::CWallWalker(const EPatternedAI chr, const TUniqueId uid, const rstl::string& name,

--- a/src/MetroidPrime/Factories/CCharacterFactory.cpp
+++ b/src/MetroidPrime/Factories/CCharacterFactory.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Factories/CCharacterFactory.hpp"
 
 #include "MetroidPrime/CAnimData.hpp"

--- a/src/MetroidPrime/Factories/CStateMachineFactory.cpp
+++ b/src/MetroidPrime/Factories/CStateMachineFactory.cpp
@@ -3,7 +3,6 @@
 
 #include <Kyoto/Streams/CInputStream.hpp>
 
-#pragma inline_max_size(250)
 const CFactoryFnReturn FAiFiniteStateMachineFactory(const SObjectTag& tag, CInputStream& in,
                                               const CVParamTransfer& xfer) {
   return rs_new CStateMachine(in);

--- a/src/MetroidPrime/HUD/CSamusHud.cpp
+++ b/src/MetroidPrime/HUD/CSamusHud.cpp
@@ -50,8 +50,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#pragma inline_max_size(250)
-
 static const char sBaseHudName[] = "FRME_BaseHud";
 static const char sHelmetName[] = "FRME_Helmet";
 static const char sCombatHudName[] = "FRME_CombatHud";

--- a/src/MetroidPrime/Player/CGameOptions.cpp
+++ b/src/MetroidPrime/Player/CGameOptions.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Player/CGameOptions.hpp"
 
 #include "MetroidPrime/Tweaks/CTweaks.hpp"

--- a/src/MetroidPrime/Player/CGameState.cpp
+++ b/src/MetroidPrime/Player/CGameState.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Player/CGameState.hpp"
 
 #include "Kyoto/CSimplePool.hpp"

--- a/src/MetroidPrime/Player/CGrappleArm.cpp
+++ b/src/MetroidPrime/Player/CGrappleArm.cpp
@@ -29,8 +29,6 @@
 #include "MetroidPrime/Weapons/GunController/CGunController.hpp"
 #include "MetroidPrime/Weapons/WeaponCommon.hpp"
 
-#pragma inline_max_size(250)
-
 static const char* const kGrappleGear = "GrappleGear";
 static const char* const kGrappleNoz1 = "GrapNoz1";
 static const char* const kGrappleNoz2 = "GrapNoz2";

--- a/src/MetroidPrime/Player/CMorphBall.cpp
+++ b/src/MetroidPrime/Player/CMorphBall.cpp
@@ -50,8 +50,6 @@
 
 #include "rstl/math.hpp"
 
-#pragma inline_max_size(250)
-
 static inline CMaterialFilter MakeBallDamageFilter() {
   return CMaterialFilter::MakeIncludeExclude(CMaterialList(kMT_Solid), CMaterialList());
 }

--- a/src/MetroidPrime/Player/CMorphBallShadow.cpp
+++ b/src/MetroidPrime/Player/CMorphBallShadow.cpp
@@ -13,8 +13,6 @@
 
 #include <float.h>
 
-#pragma inline_max_size(250)
-
 CMorphBallShadow::CMorphBallShadow(int width, int height, const TToken< CTexture >& ballFade)
 : x40_texture(kTF_I8, width, height, 1)
 , xa8_ballFade(ballFade)

--- a/src/MetroidPrime/Player/CPlayer.cpp
+++ b/src/MetroidPrime/Player/CPlayer.cpp
@@ -75,8 +75,6 @@
 #include "rstl/math.hpp"
 #include "rstl/vector.hpp"
 
-#pragma inline_max_size(250)
-
 const bool gkAutoAim = false;
 const bool gkAutoAimAtOrbitedObject = false;
 const bool gkFreeLookPreventsOrbitMovement = true;

--- a/src/MetroidPrime/Player/CPlayerDynamics.cpp
+++ b/src/MetroidPrime/Player/CPlayerDynamics.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Player/CPlayer.hpp"
 
 #include "MetroidPrime/Player/CGameState.hpp"

--- a/src/MetroidPrime/Player/CPlayerEnergyDrain.cpp
+++ b/src/MetroidPrime/Player/CPlayerEnergyDrain.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Player/CPlayerEnergyDrain.hpp"
 
 #include "MetroidPrime/CStateManager.hpp"

--- a/src/MetroidPrime/Player/CPlayerGun.cpp
+++ b/src/MetroidPrime/Player/CPlayerGun.cpp
@@ -69,8 +69,6 @@
 
 #include "math.h"
 
-#pragma inline_max_size(250)
-
 static const char* const kGunLocator = "GBSE_SDK";
 const float CPlayerGun::kGunScale = 2.f;
 

--- a/src/MetroidPrime/Player/CSamusFaceReflection.cpp
+++ b/src/MetroidPrime/Player/CSamusFaceReflection.cpp
@@ -19,8 +19,6 @@
 #include "Kyoto/Graphics/CModelFlags.hpp"
 #include "Kyoto/Math/CRelAngle.hpp"
 
-#pragma inline_max_size(250)
-
 static const char* const skFaceAssetIdName = "ACS_SamusFace";
 static const CTransform4f skFaceModelViewAdjust =
     CTransform4f::Scale(0.3f) * CTransform4f::Translate(CVector3f(0.f, 0.5f, 0.f));

--- a/src/MetroidPrime/Player/CScanDisplay.cpp
+++ b/src/MetroidPrime/Player/CScanDisplay.cpp
@@ -22,8 +22,6 @@
 
 #include <rstl/math.hpp>
 
-#pragma inline_max_size(250)
-
 void CScanDisplay::SetScanMessageTypeEffect(CGuiTextPane* pane, bool type) {
   if (type) {
     pane->TextSupport().SetTypeWriteEffectOptions(true, 0.1f, 60.f);

--- a/src/MetroidPrime/Player/CStaticInterference.cpp
+++ b/src/MetroidPrime/Player/CStaticInterference.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Player/CStaticInterference.hpp"
 
 #include "Kyoto/Math/CMath.hpp"

--- a/src/MetroidPrime/ScriptLoader.cpp
+++ b/src/MetroidPrime/ScriptLoader.cpp
@@ -144,8 +144,6 @@
 #include "Kyoto/Math/CVector2f.hpp"
 #include "Kyoto/Streams/CInputStream.hpp"
 
-#pragma inline_max_size(250)
-
 static CAABox GetCollisionBox(CStateManager& stateMgr, TAreaId id, const CVector3f& extent,
                               const CVector3f& offset) {
   const CAABox box(-extent.GetX() / 2.f + offset.GetX(), -extent.GetY() / 2.f + offset.GetY(),

--- a/src/MetroidPrime/ScriptObjects/CFishCloud.cpp
+++ b/src/MetroidPrime/ScriptObjects/CFishCloud.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/ScriptObjects/CFishCloud.hpp"
 #include "MetroidPrime/ScriptObjects/CFishCloudModifier.hpp"
 

--- a/src/MetroidPrime/ScriptObjects/CScriptCameraHint.cpp
+++ b/src/MetroidPrime/ScriptObjects/CScriptCameraHint.cpp
@@ -7,8 +7,6 @@
 
 #include "rstl/algorithm.hpp"
 
-#pragma inline_max_size(250)
-
 CCameraOverrideInfo::CCameraOverrideInfo(
     uint overrideFlags, CBallCamera::EBallCameraBehaviour behaviour, float minDist, float maxDist,
     float backwardsDist, const CVector3f& lookAtOffset, const CVector3f& chaseLookAtOffset,

--- a/src/MetroidPrime/ScriptObjects/CScriptDamageableTrigger.cpp
+++ b/src/MetroidPrime/ScriptObjects/CScriptDamageableTrigger.cpp
@@ -13,8 +13,6 @@
 #include "Kyoto/Math/CRelAngle.hpp"
 #include "Kyoto/Math/CloseEnough.hpp"
 
-#pragma inline_max_size(250)
-
 CScriptDamageableTrigger::CScriptDamageableTrigger(
     TUniqueId uid, const rstl::string& name, const CEntityInfo& info, const CVector3f& position,
     const CVector3f& extent, const CHealthInfo& hInfo, const CDamageVulnerability& dVuln,

--- a/src/MetroidPrime/ScriptObjects/CScriptEffect.cpp
+++ b/src/MetroidPrime/ScriptObjects/CScriptEffect.cpp
@@ -20,8 +20,6 @@
 #include "MetroidPrime/TCastTo.hpp"
 
 #include "rstl/math.hpp"
-#pragma inline_max_size(250)
-
 uint CScriptEffect::mNumParticlesDrawing = 0;
 uint CScriptEffect::mNumParticlesUpdating = 0;
 

--- a/src/MetroidPrime/ScriptObjects/CScriptGenerator.cpp
+++ b/src/MetroidPrime/ScriptObjects/CScriptGenerator.cpp
@@ -6,7 +6,6 @@
 
 #include "rstl/algorithm.hpp"
 
-#pragma inline_max_size(250)
 CScriptGenerator::CScriptGenerator(const TUniqueId uid, const rstl::string& name,
                                    const CEntityInfo& info, const int spawnCount,
                                    const bool noReuseFollowers, const CVector3f& vec1,

--- a/src/MetroidPrime/ScriptObjects/CScriptGunTurret.cpp
+++ b/src/MetroidPrime/ScriptObjects/CScriptGunTurret.cpp
@@ -98,7 +98,6 @@ const SBurst* CScriptGunTurret::skBursts[] = {
     nullptr,
 };
 
-#pragma inline_max_size(250)
 CScriptGunTurretData::CScriptGunTurretData(CInputStream& in, const int propCount)
 : x0_intoDeactivateDelay(in.Get< float >())
 , x4_intoActivateDelay(in.Get< float >())

--- a/src/MetroidPrime/ScriptObjects/CScriptPlatform.cpp
+++ b/src/MetroidPrime/ScriptObjects/CScriptPlatform.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/ScriptObjects/CScriptPlatform.hpp"
 
 #include "MetaRender/CCubeRenderer.hpp"

--- a/src/MetroidPrime/ScriptObjects/CScriptPlayerActor.cpp
+++ b/src/MetroidPrime/ScriptObjects/CScriptPlayerActor.cpp
@@ -22,8 +22,6 @@
 #include "Kyoto/Math/CMath.hpp"
 #include "MetaRender/CCubeRenderer.hpp"
 
-#pragma inline_max_size(250)
-
 static const char* const kGunLocator = "GUN_LCTR";
 
 CScriptPlayerActor::CScriptPlayerActor(TUniqueId uid, const rstl::string& name,

--- a/src/MetroidPrime/ScriptObjects/CScriptRandomRelay.cpp
+++ b/src/MetroidPrime/ScriptObjects/CScriptRandomRelay.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/ScriptObjects/CScriptRandomRelay.hpp"
 
 #include "MetroidPrime/CStateManager.hpp"

--- a/src/MetroidPrime/ScriptObjects/CScriptSpecialFunction.cpp
+++ b/src/MetroidPrime/ScriptObjects/CScriptSpecialFunction.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/ScriptObjects/CScriptSpecialFunction.hpp"
 
 #include "MetroidPrime/CActorParameters.hpp"

--- a/src/MetroidPrime/ScriptObjects/CScriptVisorFlare.cpp
+++ b/src/MetroidPrime/ScriptObjects/CScriptVisorFlare.cpp
@@ -5,8 +5,6 @@
 #include "MetroidPrime/Player/CPlayer.hpp"
 
 // TODO inline depth hack
-#pragma inline_max_size(200)
-
 CScriptVisorFlare::CScriptVisorFlare(TUniqueId uid, const rstl::string& name,
                                      const CEntityInfo& info, const bool active,
                                      const CVector3f& pos, CVisorFlare::EBlendMode blendMode,

--- a/src/MetroidPrime/ScriptObjects/CScriptWater.cpp
+++ b/src/MetroidPrime/ScriptObjects/CScriptWater.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/ScriptObjects/CScriptWater.hpp"
 
 #include "MetroidPrime/CActorLights.hpp"

--- a/src/MetroidPrime/Tweaks/CTweakGuiColors.cpp
+++ b/src/MetroidPrime/Tweaks/CTweakGuiColors.cpp
@@ -2,7 +2,6 @@
 
 CTweakGuiColors::~CTweakGuiColors() {}
 
-#pragma inline_max_size(250)
 CTweakGuiColors::CTweakGuiColors(CInputStream& in)
 : x4_pauseBlurFilterColor(in)
 , x8_radarStuffColor(in)

--- a/src/MetroidPrime/Tweaks/CTweakPlayerRes.cpp
+++ b/src/MetroidPrime/Tweaks/CTweakPlayerRes.cpp
@@ -7,8 +7,6 @@
 
 #include <string.h>
 
-#pragma inline_max_size(250)
-
 static inline CAssetId get_asset_id_from_name(const char* name) {
   CAssetId id = gpResourceFactory->GetResourceIdByName(name)->GetId();
   return id;

--- a/src/MetroidPrime/Tweaks/CTweakTargeting.cpp
+++ b/src/MetroidPrime/Tweaks/CTweakTargeting.cpp
@@ -3,8 +3,6 @@
 #include "Kyoto/Math/CMath.hpp"
 #include "Kyoto/Streams/CInputStream.hpp"
 
-#pragma inline_max_size(250)
-
 CTweakTargeting::CTweakTargeting(CInputStream& in)
 : x4_targetRadiusMode(in.ReadLong())
 , x8_currLockOnExitDuration(in.ReadFloat())

--- a/src/MetroidPrime/Weapons/CAuxWeapon.cpp
+++ b/src/MetroidPrime/Weapons/CAuxWeapon.cpp
@@ -14,8 +14,6 @@
 #include "MetroidPrime/Weapons/CWaveBuster.hpp"
 #include "MetroidPrime/Weapons/CWeaponAssetInfo.hpp"
 
-#pragma inline_max_size(250)
-
 const ushort CAuxWeapon::skSoundId[5] = {SFXsam_a_co1fire_00, SFXsam_a_icecofir_00,
                                          SFXsam_a_wavcofir_lp_00, SFXsam_a_placofir_lp_00,
                                          SFXsam_a_co1fire_00};

--- a/src/MetroidPrime/Weapons/CFlameThrower.cpp
+++ b/src/MetroidPrime/Weapons/CFlameThrower.cpp
@@ -9,8 +9,6 @@
 #include "MetroidPrime/Player/CPlayer.hpp"
 #include "MetroidPrime/TCastTo.hpp"
 
-#pragma inline_max_size(250)
-
 const CVector3f CFlameThrower::kLightOffset = CVector3f(0.f, 3.f, 2.f);
 
 CFlameThrower::CFlameThrower(const TToken< CWeaponDescription >& wDesc, const rstl::string& name,

--- a/src/MetroidPrime/Weapons/CGameProjectile.cpp
+++ b/src/MetroidPrime/Weapons/CGameProjectile.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Weapons/CGameProjectile.hpp"
 #include "Collision/CCollidableAABox.hpp"
 #include "Collision/CMaterialList.hpp"

--- a/src/MetroidPrime/Weapons/CGunWeapon.cpp
+++ b/src/MetroidPrime/Weapons/CGunWeapon.cpp
@@ -28,8 +28,6 @@
 #include "Kyoto/Particles/CElementGen.hpp"
 #include "MetaRender/CCubeRenderer.hpp"
 
-#pragma inline_max_size(250)
-
 const char* const CGunWeapon::skMuzzleNames[10] = {
     "PowerMuzzle", "PowerCharge",  "IceMuzzle",    "IceCharge",    "PowerMuzzle",
     "WaveCharge",  "PlasmaMuzzle", "PlasmaCharge", "PhazonMuzzle", "EmptyMuzzle",

--- a/src/MetroidPrime/Weapons/CIceProjectile.cpp
+++ b/src/MetroidPrime/Weapons/CIceProjectile.cpp
@@ -16,8 +16,6 @@
 #include "Kyoto/Math/CRelAngle.hpp"
 #include "Kyoto/Particles/CElementGen.hpp"
 
-#pragma inline_max_size(250)
-
 CIceAttackProjectile::CIceAttackProjectile(TToken< CGenDescription > trail,
                                            TToken< CGenDescription > explosion,
                                            TToken< CGenDescription > moving, TUniqueId uid,

--- a/src/MetroidPrime/Weapons/CNewFlameThrower.cpp
+++ b/src/MetroidPrime/Weapons/CNewFlameThrower.cpp
@@ -28,8 +28,6 @@
 #include "WorldFormat/CMetroidAreaCollider.hpp"
 #include "rstl/algorithm.hpp"
 
-#pragma inline_max_size(250)
-
 static const CMaterialFilter skExcludeProjectilePassthrough =
     CMaterialFilter::MakeExclude(CMaterialList(kMT_ProjectilePassthrough));
 

--- a/src/MetroidPrime/Weapons/CPlasmaProjectile.cpp
+++ b/src/MetroidPrime/Weapons/CPlasmaProjectile.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Weapons/CPlasmaProjectile.hpp"
 #include "Kyoto/Graphics/CGX.hpp"
 #include "Kyoto/Graphics/CGraphics.hpp"

--- a/src/MetroidPrime/Weapons/CWaveBuster.cpp
+++ b/src/MetroidPrime/Weapons/CWaveBuster.cpp
@@ -18,8 +18,6 @@
 #include "dolphin/gx.h"
 #include "dolphin/os/OSCache.h"
 
-#pragma inline_max_size(250)
-
 static const CVector3f kTargetNodePosition(0.f, -3.f, -1.5f);
 static const CVector3f kSourceNodePosition(0.f, 2.f, 1.5f);
 

--- a/src/MetroidPrime/Weapons/GunController/CGSFidget.cpp
+++ b/src/MetroidPrime/Weapons/GunController/CGSFidget.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Weapons/GunController/CGSFidget.hpp"
 
 #include "MetroidPrime/CAnimData.hpp"

--- a/src/MetroidPrime/Weapons/GunController/CGunMotion.cpp
+++ b/src/MetroidPrime/Weapons/GunController/CGunMotion.cpp
@@ -9,8 +9,6 @@
 #include "Kyoto/Animation/CPASDatabase.hpp"
 #include "Kyoto/Graphics/CModelFlags.hpp"
 
-#pragma inline_max_size(250)
-
 CGunMotion::CGunMotion(CAssetId ancsId, const CVector3f& scale)
 : x0_modelData(CAnimRes(ancsId, 0, scale, 0, false))
 , x4c_gunController(x0_modelData)

--- a/src/MetroidPrime/Weapons/WeaponTypes.cpp
+++ b/src/MetroidPrime/Weapons/WeaponTypes.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "MetroidPrime/Weapons/WeaponTypes.hpp"
 #include "Kyoto/SObjectTag.hpp"
 #include "MetroidPrime/Weapons/WeaponCommon.hpp"

--- a/src/MetroidPrime/main.cpp
+++ b/src/MetroidPrime/main.cpp
@@ -109,8 +109,6 @@ const CFactoryFnReturn FDependencyGroupFactory(const SObjectTag&, CInputStream&,
 const CFactoryFnReturn FSaveWorldFactory(const SObjectTag&, CInputStream&, const CVParamTransfer&);
 const CFactoryFnReturn FHintFactory(const SObjectTag&, CInputStream&, const CVParamTransfer&);
 
-#pragma inline_max_size(250)
-
 CResFactory* gpResourceFactory;
 CSimplePool* gpSimplePool;
 CCubeRenderer* gpRender;

--- a/src/Weapons/CCollisionResponseData.cpp
+++ b/src/Weapons/CCollisionResponseData.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "Weapons/CCollisionResponseData.hpp"
 
 #include "Kyoto/CFactoryFnReturn.hpp"

--- a/src/Weapons/CProjectileWeapon.cpp
+++ b/src/Weapons/CProjectileWeapon.cpp
@@ -19,8 +19,6 @@
 #include <MetaRender/CCubeRenderer.hpp>
 #include <Weapons/CCollisionResponseData.hpp>
 
-#pragma inline_max_size(250)
-
 uint CProjectileWeapon::skGlobalSeed = 99;
 
 float CProjectileWeapon::GetTickPeriod() { return 1 / 60.f; }

--- a/src/WorldFormat/CAreaOctTree_Tests.cpp
+++ b/src/WorldFormat/CAreaOctTree_Tests.cpp
@@ -6,8 +6,6 @@
 #include "math.h"
 #include "rstl/algorithm.hpp"
 
-#pragma inline_max_size(250)
-
 struct SSubdivision {
   int count;
   CVector3i axes;

--- a/src/WorldFormat/CAreaRenderOctTree.cpp
+++ b/src/WorldFormat/CAreaRenderOctTree.cpp
@@ -1,7 +1,5 @@
 #include "WorldFormat/CAreaRenderOctTree.hpp"
 
-#pragma inline_max_size(250)
-
 static const int skChildCounts[] = {0, 2, 2, 4, 2, 4, 4, 8};
 // Retail indexes this table with flags * 3, including its unusual axis pairs.
 static const int skAxes[] = {-1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 1, -1, -1, 0, 2, 1, 2, 0, 1};

--- a/src/WorldFormat/CCollidableOBBTreeGroup.cpp
+++ b/src/WorldFormat/CCollidableOBBTreeGroup.cpp
@@ -9,8 +9,6 @@
 #include "WorldFormat/CCollidableOBBTree.hpp"
 #include "WorldFormat/COBBTree.hpp"
 
-#pragma inline_max_size(250)
-
 uint CCollidableOBBTreeGroup::sTableIndex = -1;
 
 const CFactoryFnReturn FCollidableOBBTreeGroupFactory(const SObjectTag& tag, CInputStream& in,

--- a/src/WorldFormat/CMetroidAreaCollider.cpp
+++ b/src/WorldFormat/CMetroidAreaCollider.cpp
@@ -1,5 +1,3 @@
-#pragma inline_max_size(250)
-
 #include "WorldFormat/CMetroidAreaCollider.hpp"
 
 #include "Collision/CMRay.hpp"

--- a/src/WorldFormat/COBBTree.cpp
+++ b/src/WorldFormat/COBBTree.cpp
@@ -5,8 +5,6 @@
 #include "Kyoto/Streams/CInputStream.hpp"
 #include "rstl/algorithm.hpp"
 
-#pragma inline_max_size(250)
-
 COBBTree::CSimpleAllocator* COBBTree::CNode::spAllocator = nullptr;
 
 COBBTree::SIndexData::SIndexData(CInputStream& in)

--- a/src/WorldFormat/CPVSAreaSet.cpp
+++ b/src/WorldFormat/CPVSAreaSet.cpp
@@ -4,7 +4,6 @@
 #include <Kyoto/Streams/CMemoryInStream.hpp>
 #include <WorldFormat/CPVSAreaSet.hpp>
 
-#pragma inline_max_size(250)
 CPVSAreaSet::CPVSAreaSet(int numFeatures, int numLights, int num2ndLights, int numActors,
                          int leafSize, int lightIndexCount, const char* w7, const char* w8,
                          const char* w9)

--- a/src/WorldFormat/CWorldLight.cpp
+++ b/src/WorldFormat/CWorldLight.cpp
@@ -3,8 +3,6 @@
 #include "Kyoto/Streams/CInputStream.hpp"
 #include <rstl/math.hpp>
 
-#pragma inline_max_size(250)
-
 const CVector3f CWorldLight::kDefaultPosition = CVector3f(0.f, 0.f, 0.f);
 const CVector3f CWorldLight::kDefaultDirection = CVector3f(0.f, 1.f, 0.f);
 


### PR DESCRIPTION
Move inlining pragmas into shared flags while preserving the TUs and regional overrides that still require different limits.