### PR TITLE
Use size and pointer integer types

### DIFF
--- a/extern/sdk/libc/stdint.h
+++ b/extern/sdk/libc/stdint.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif
 
+typedef signed long int intptr_t;
 typedef unsigned long int uintptr_t;
 
 #ifdef __cplusplus

--- a/include/MetroidPrime/CGameArea.hpp
+++ b/include/MetroidPrime/CGameArea.hpp
@@ -183,7 +183,7 @@ public:
     rstl::single_ptr< CAreaObjectList > x10c0_areaObjectList;
     rstl::single_ptr< CAreaFog > x10c4_areaFog;
     rstl::auto_ptr< char > x10c8_sclyBuf;
-    u32 x10d0_sclySize;
+    size_t x10d0_sclySize;
     const u8* x10d4_firstMatPtr;
     const CScriptAreaAttributes* x10d8_areaAttributes;
     EOcclusionState x10dc_occlusionState;

--- a/include/MetroidPrime/PathFinding/CPathFindArea.hpp
+++ b/include/MetroidPrime/PathFinding/CPathFindArea.hpp
@@ -144,11 +144,12 @@ inline void CPFAreaOctree::Fixup(CPFArea& area) {
   x0_isLeaf = *reinterpret_cast< const int* >(this) != 0;
   if (x0_isLeaf) {
     if (x48_regions.size() != 0) {
-      x48_regions.set_data(&area.GetOctreeRegionPtrs(reinterpret_cast< int >(&x48_regions[0])));
+      x48_regions.set_data(
+          &area.GetOctreeRegionPtrs(reinterpret_cast< intptr_t >(&x48_regions[0])));
     }
   } else {
     for (int i = 0; i < 8; ++i) {
-      int index = reinterpret_cast< int >(x28_children[i]);
+      intptr_t index = reinterpret_cast< intptr_t >(x28_children[i]);
       x28_children[i] = index >= 0 ? &area.GetOctree(index) : nullptr;
     }
   }

--- a/src/Kyoto/Alloc/CGameAllocator.cpp
+++ b/src/Kyoto/Alloc/CGameAllocator.cpp
@@ -68,7 +68,9 @@ CGameAllocator::~CGameAllocator() {
 bool CGameAllocator::Initialize(COsContext& ctx) {
   x8_heapSize = ctx.GetBaseFreeRam() - 2 * sizeof(SGameMemInfo);
   xc_first = static_cast< SGameMemInfo* >(OSAllocFromArenaLo(x8_heapSize, sizeof(SGameMemInfo)));
-  xb4_physicalAddr = (void*)((int)this->xc_first - ((uint)(xc_first) & 0xf0000000));
+  xb4_physicalAddr =
+      reinterpret_cast< void* >(reinterpret_cast< intptr_t >(xc_first) -
+                                (reinterpret_cast< uintptr_t >(xc_first) & 0xf0000000));
   OSGetArenaLo();
   x10_last =
       reinterpret_cast< SGameMemInfo* >(reinterpret_cast< char* >(xc_first - 1) + x8_heapSize);

--- a/src/Kyoto/Alloc/CMediumAllocPool.cpp
+++ b/src/Kyoto/Alloc/CMediumAllocPool.cpp
@@ -180,8 +180,8 @@ void SMediumAllocPuddle::Free(const void* ptr) {
   uchar* bookKeepingPtr;
   ushort mergedCount;
   bool isCached;
-  uint blockOffset = (reinterpret_cast< uint >(ptr) -
-                      reinterpret_cast< uint >(x0_mainData.get())) / 32;
+  size_t blockOffset =
+      (reinterpret_cast< uintptr_t >(ptr) - reinterpret_cast< uintptr_t >(x0_mainData.get())) / 32;
   uint blockCount = x8_bookKeeping[blockOffset];
   mergedCount = blockCount;
   isCached = false;

--- a/src/Kyoto/Audio/CDSPStream.cpp
+++ b/src/Kyoto/Audio/CDSPStream.cpp
@@ -82,7 +82,7 @@ void CDSPStream::DoAllocateStream() {
       static_cast< u8 >(0xFF), xd4_buffer, xdc_streamSamples, static_cast< u32 >(32000),
       static_cast< u8 >(0), static_cast< u8 >(0x40), static_cast< u8 >(0), static_cast< u8 >(0),
       static_cast< u8 >(0), static_cast< u8 >(0), static_cast< u32 >(0x30001), UpdateStream,
-      reinterpret_cast< u32 >(this), static_cast< SND_ADPCMSTREAM_INFO* >(nullptr));
+      reinterpret_cast< uintptr_t >(this), static_cast< SND_ADPCMSTREAM_INFO* >(nullptr));
 }
 
 void CDSPStream::Initialize() {

--- a/src/Kyoto/Audio/CStaticAudioPlayer.cpp
+++ b/src/Kyoto/Audio/CStaticAudioPlayer.cpp
@@ -127,7 +127,8 @@ void CStaticAudioPlayer::MixCallback() { sCurrentPlayer->DoMix(); }
 void CStaticAudioPlayer::DoMix() {
   u32 aiStart = OSCachedToPhysical(AIGetDMAStartAddr());
   x24_curBuf ^= 1;
-  u32 buf = (u32)(x24_curBuf != 0 ? x30_dmaRight.get() : x28_dmaLeft.get());
+  uintptr_t buf =
+      reinterpret_cast< uintptr_t >(x24_curBuf != 0 ? x30_dmaRight.get() : x28_dmaLeft.get());
 
   AIInitDMA(buf, 0x280);
   u32 cookie = OSEnableInterrupts();

--- a/src/Kyoto/Audio/DolphinCAudioSys.cpp
+++ b/src/Kyoto/Audio/DolphinCAudioSys.cpp
@@ -331,7 +331,7 @@ bool CAudioSys::SysPushGroupIntoARAM(const rstl::string& name, const uchar group
     void* pool = group->GetPoolBuffer();
     uchar buffer[0x1020];
     mpSampleDataUploadBuffer =
-        reinterpret_cast< void* >((reinterpret_cast< uint >(buffer) + 31) & ~31);
+        reinterpret_cast< void* >((reinterpret_cast< uintptr_t >(buffer) + 31) & ~31);
     sndSetSampleDataUploadCallback(SampleDataUploadCallback, 0x1000);
     const bool result = sndPushGroup(project, groupId, samples, sampleDir, pool);
     sndSetSampleDataUploadCallback(nullptr, 0);

--- a/src/Kyoto/CARAMManager.cpp
+++ b/src/Kyoto/CARAMManager.cpp
@@ -98,7 +98,7 @@ bool CARAMManager::Free(const void* ptr) {
     return false;
   }
 
-  uint blockStart = ((u32)ptr - mpARAMStart) / mChunkSize;
+  uint blockStart = (reinterpret_cast< uintptr_t >(ptr) - mpARAMStart) / mChunkSize;
   uint blockCount = mpBookKeepingMemory[blockStart];
   mChunksAllocated -= blockCount;
   while (blockCount--) {
@@ -114,8 +114,9 @@ uint CARAMManager::DMAToARAM(void* src, void* dest, uint len, EDMAPriority prior
   req->mUniqueID = mDMAUniqueID;
   mActiveDMAs.push_back(req);
   ARQPostRequest(&req->mRequest, req->mUniqueID, ARQ_TYPE_MRAM_TO_ARAM,
-                 (priority == kDMAPrio_One) ? ARQ_PRIORITY_HIGH : ARQ_PRIORITY_LOW, (u32)src,
-                 (u32)dest, len, AramManagerDMACallback);
+                 (priority == kDMAPrio_One) ? ARQ_PRIORITY_HIGH : ARQ_PRIORITY_LOW,
+                 reinterpret_cast< uintptr_t >(src), reinterpret_cast< uintptr_t >(dest), len,
+                 AramManagerDMACallback);
 
   GetAndIncrementUniqueID();
   return req->mUniqueID;
@@ -128,8 +129,9 @@ int CARAMManager::DMAToMRAM(void* src, void* dest, uint len, EDMAPriority priori
   req->mUniqueID = mDMAUniqueID;
   mActiveDMAs.push_back(req);
   ARQPostRequest(&req->mRequest, req->mUniqueID, ARQ_TYPE_ARAM_TO_MRAM,
-                 (priority == kDMAPrio_One) ? ARQ_PRIORITY_HIGH : ARQ_PRIORITY_LOW, (u32)src,
-                 (u32)dest, len, AramManagerDMACallback);
+                 (priority == kDMAPrio_One) ? ARQ_PRIORITY_HIGH : ARQ_PRIORITY_LOW,
+                 reinterpret_cast< uintptr_t >(src), reinterpret_cast< uintptr_t >(dest), len,
+                 AramManagerDMACallback);
 
   GetAndIncrementUniqueID();
   return req->mUniqueID;

--- a/src/Kyoto/DolphinCDvdFile.cpp
+++ b/src/Kyoto/DolphinCDvdFile.cpp
@@ -97,8 +97,8 @@ void CDvdFile::PingARAMTransfer() {
 
   int length = rstl::min_val(65536, aramFile->mBufferLen);
   ARQPostRequest(&aramFile->mARQRequest, 0, ARQ_TYPE_MRAM_TO_ARAM, ARQ_PRIORITY_HIGH,
-                 reinterpret_cast< u32 >(aramFile->mBuffers[aramFile->mBufferIndex].get()),
-                 reinterpret_cast< u32 >(mARAMBuffer + aramFile->mAramOffset), length,
+                 reinterpret_cast< uintptr_t >(aramFile->mBuffers[aramFile->mBufferIndex].get()),
+                 reinterpret_cast< uintptr_t >(mARAMBuffer + aramFile->mAramOffset), length,
                  ARAMARAMXferCallback);
 
   aramFile->mBufferLen -= length;

--- a/src/Kyoto/Graphics/CCubeMoviePlayer.cpp
+++ b/src/Kyoto/Graphics/CCubeMoviePlayer.cpp
@@ -345,7 +345,7 @@ void CMoviePlayer::ReadCompleted() {
 
 void CMoviePlayer::DecodeFromRead(const void* ptr) {
   uchar work[4096 + 32];
-  void* alignedWork = reinterpret_cast< void* >(OSRoundUp32B(reinterpret_cast< uint >(work)));
+  void* alignedWork = reinterpret_cast< void* >((reinterpret_cast< uintptr_t >(work) + 31) & ~31);
   if (x80_textures.empty()) {
     InitializeTextures();
   }
@@ -526,7 +526,7 @@ void CMoviePlayer::StaticMyAudioCallback() {
     curAudioBuffer = static_cast< const short* >(OSPhysicalToCached(AIGetDMAStartAddr()));
     soundBufferIndex ^= 1;
     short* buffer = soundBuffer[soundBufferIndex];
-    AIInitDMA(reinterpret_cast< u32 >(buffer), sizeof(soundBuffer[0]));
+    AIInitDMA(reinterpret_cast< uintptr_t >(buffer), sizeof(soundBuffer[0]));
     const BOOL interrupts = OSEnableInterrupts();
     if (curAudioBuffer != nullptr) {
       DCInvalidateRange(const_cast< short* >(curAudioBuffer), sizeof(soundBuffer[0]));

--- a/src/Kyoto/Graphics/DolphinCModel.cpp
+++ b/src/Kyoto/Graphics/DolphinCModel.cpp
@@ -291,15 +291,16 @@ uint CModel::GetDataSize() const { return x4_dataLen; }
 rstl::auto_ptr< uchar > CModel::GetData() { return rstl::auto_ptr< uchar >(x0_data.get()); }
 
 namespace {
-inline void RemapPointer(const void*& pointer, uint offset) {
+inline void RemapPointer(const void*& pointer, uintptr_t offset) {
   if (pointer != nullptr) {
-    pointer = reinterpret_cast< void* >(reinterpret_cast< uint >(pointer) + offset);
+    pointer = reinterpret_cast< void* >(reinterpret_cast< uintptr_t >(pointer) + offset);
   }
 }
 } // namespace
 
 void CModel::RemapData(uchar* data) {
-  uint offset = reinterpret_cast< uint >(data) - reinterpret_cast< uint >(x0_data.release());
+  uintptr_t offset =
+      reinterpret_cast< uintptr_t >(data) - reinterpret_cast< uintptr_t >(x0_data.release());
   x0_data = data;
   for (int i = 0; i < x18_matSets.size(); ++i) {
     RemapPointer(reinterpret_cast< const void*& >(x18_matSets[i].x10_data), offset);

--- a/src/Kyoto/Particles/CElementGen.cpp
+++ b/src/Kyoto/Particles/CElementGen.cpp
@@ -2016,8 +2016,8 @@ void CElementGen::RenderParticlesIndirectTexture() {
       GXSetTexCopyDst(static_cast< u16 >(width), static_cast< u16 >(height), GX_TF_RGB565,
                       GX_FALSE);
 
-      u32 bufSize = CGraphics::GetSpareBufferSize();
-      u32 texBufSize = GXGetTexBufferSize(width, height, GX_TF_RGB565, GX_FALSE, 0);
+      size_t bufSize = CGraphics::GetSpareBufferSize();
+      size_t texBufSize = GXGetTexBufferSize(width, height, GX_TF_RGB565, GX_FALSE, 0);
       if (texBufSize <= bufSize) {
         const bool useVideoFilter = CGraphics::GetUseVideoFilter();
         CGraphics::SetUseVideoFilter(false);

--- a/src/MetroidPrime/CGameArea.cpp
+++ b/src/MetroidPrime/CGameArea.cpp
@@ -314,7 +314,7 @@ void CGameArea::PostConstructArea() {
 
   char* collisionData = section->first.get();
   ++collisionData;
-  while (reinterpret_cast< uint >(collisionData) & 3) {
+  while (reinterpret_cast< uintptr_t >(collisionData) & 3) {
     ++collisionData;
   }
   uint collisionSize = CBasics::SwapBytes(*reinterpret_cast< const uint* >(collisionData));

--- a/src/MetroidPrime/PathFinding/CPathFindArea.cpp
+++ b/src/MetroidPrime/PathFinding/CPathFindArea.cpp
@@ -114,7 +114,7 @@ CPFArea::CPFArea(const rstl::auto_ptr< uchar >& data, int size)
       static_cast< CPFRegion** >(stream.GetBlock(numRegionPtrs, sizeof(CPFRegion*))));
   for (i = 0; i < numRegionPtrs; ++i) {
     CPFRegion* const& region = x160_octreeRegions[i];
-    x160_octreeRegions[i] = &x150_regions[reinterpret_cast< int >(region)];
+    x160_octreeRegions[i] = &x150_regions[reinterpret_cast< intptr_t >(region)];
   }
   int numOctreeNodes = stream.ReadInt32();
   x158_octree.set_size(numOctreeNodes);

--- a/src/MetroidPrime/PathFinding/CPathFindRegion.cpp
+++ b/src/MetroidPrime/PathFinding/CPathFindRegion.cpp
@@ -20,8 +20,8 @@ CPFRegionData::CPFRegionData()
 , x2c_parentLink(0) {}
 
 void CPFRegion::Fixup(CPFArea& area, int& numNodes) {
-  x4_startNode = x0_numNodes ? &area.GetNode(reinterpret_cast< int >(x4_startNode)) : nullptr;
-  xc_startLink = x8_numLinks ? &area.GetLink(reinterpret_cast< int >(xc_startLink)) : nullptr;
+  x4_startNode = x0_numNodes ? &area.GetNode(reinterpret_cast< intptr_t >(x4_startNode)) : nullptr;
+  xc_startLink = x8_numLinks ? &area.GetLink(reinterpret_cast< intptr_t >(xc_startLink)) : nullptr;
   x4c_data = &area.GetRegionData(x24_regionIdx);
   if (x0_numNodes > numNodes) {
     numNodes = x0_numNodes;

--- a/src/NESemu/emu.cpp
+++ b/src/NESemu/emu.cpp
@@ -793,11 +793,11 @@ int ksNesReset(ksNesCommonWorkObj* wp, ksNesStateObj* sp, u32 flags, u8* chrramp
   };
   static const u8 table[] = {0, 0, 0, 0, 4, 4, 4, 4, 0, 4, 0, 4, 0, 0, 4, 4};
 
-  if ((reinterpret_cast< u32 >(wp) & 0x1f) || (reinterpret_cast< u32 >(sp) & 0x1f) ||
-      (reinterpret_cast< u32 >(&wp->draw_ctx) & 0x1f) ||
-      (reinterpret_cast< u32 >(&wp->draw_ctx.ppu_scanline_regs) & 0x1f) ||
-      (reinterpret_cast< u32 >(sp->ppu_chr_banks) & 3) ||
-      (reinterpret_cast< u32 >(&wp->draw_ctx.post_process_lut) & 0x1f)) {
+  if ((reinterpret_cast< uintptr_t >(wp) & 0x1f) || (reinterpret_cast< uintptr_t >(sp) & 0x1f) ||
+      (reinterpret_cast< uintptr_t >(&wp->draw_ctx) & 0x1f) ||
+      (reinterpret_cast< uintptr_t >(&wp->draw_ctx.ppu_scanline_regs) & 0x1f) ||
+      (reinterpret_cast< uintptr_t >(sp->ppu_chr_banks) & 3) ||
+      (reinterpret_cast< uintptr_t >(&wp->draw_ctx.post_process_lut) & 0x1f)) {
     return 0x52d;
   }
 
@@ -3448,8 +3448,8 @@ void ksNesDrawMakeBGIndTex(ksNesCommonWorkObj* wp, u32 mmc3) {
       }
       nametable = wp->draw_ctx.ppu_scanline_regs[row].nametable_ptrs[(ctrl1 >> 8) & 1];
       if (reinterpret_cast< s32 >(nametable) >= 0) {
-        palette = (reinterpret_cast< u32 >(nametable) & 3) | (palette << 4);
-        tile = (reinterpret_cast< u32 >(nametable) >> 8) & 0xff;
+        palette = (reinterpret_cast< uintptr_t >(nametable) & 3) | (palette << 4);
+        tile = (reinterpret_cast< uintptr_t >(nametable) >> 8) & 0xff;
       } else {
         palette = ((nametable[0x3c0 + ((ctrl0 & 0xe0) >> 2) + ((ctrl1 & 0xe0) >> 5)] >>
                     (((ctrl1 >> 3) & 2) | ((ctrl0 & 0x10) >> 2))) &


### PR DESCRIPTION
Use size_t, uintptr_t and intptr_t for byte counts and pointer conversions without changing object bytes in any enabled GameCube build.