### PR TITLE
Align raw storage on modern compilers

### DIFF
--- a/include/Kyoto/TOneStatic.hpp
+++ b/include/Kyoto/TOneStatic.hpp
@@ -28,7 +28,7 @@ uint& TOneStatic< T >::ReferenceCount() {
 
 template < typename T >
 void* TOneStatic< T >::GetAllocSpace() {
-  static char sAllocSpace[sizeof(T)];
+  ALIGNAS(T) static char sAllocSpace[sizeof(T)];
   return &sAllocSpace;
 }
 

--- a/include/rstl/construction_deferred.hpp
+++ b/include/rstl/construction_deferred.hpp
@@ -33,7 +33,7 @@ public:
   T& operator*() { return data(); }
 
 private:
-  uchar x0_data[sizeof(T)];
+  ALIGNAS(T) uchar x0_data[sizeof(T)];
   bool m_valid __attribute__((aligned(4)));
 
   void makeValid() { m_valid = true; }

--- a/include/rstl/list.hpp
+++ b/include/rstl/list.hpp
@@ -95,7 +95,7 @@ public:
   struct node {
     node* x0_prev;
     node* x4_next;
-    uchar x8_item[sizeof(T)];
+    ALIGNAS(T) uchar x8_item[sizeof(T)];
 
     node(node* prev, node* next) : x0_prev(prev), x4_next(next) {}
 

--- a/include/rstl/optional_object.hpp
+++ b/include/rstl/optional_object.hpp
@@ -57,7 +57,7 @@ public:
   const T* operator->() const { return &data(); }
 
 private:
-  uchar m_data[sizeof(T)];
+  ALIGNAS(T) uchar m_data[sizeof(T)];
   bool m_valid ATTRIBUTE_ALIGN(4);
 
   void assign(const T& item) {

--- a/include/rstl/red_black_tree.hpp
+++ b/include/rstl/red_black_tree.hpp
@@ -27,7 +27,7 @@ private:
     node* mRight;
     node* mParent;
     node_color mColor;
-    uchar mValue[sizeof(P)];
+    ALIGNAS(P) uchar mValue[sizeof(P)];
 
     node(node* left, node* right, node* parent, node_color color, const P& value)
     : mLeft(left), mRight(right), mParent(parent), mColor(color) {

--- a/include/rstl/reserved_vector.hpp
+++ b/include/rstl/reserved_vector.hpp
@@ -13,7 +13,7 @@ namespace rstl {
 template < typename T, int N >
 class reserved_vector {
   int x0_count;
-  uchar x4_data[N * sizeof(T)];
+  ALIGNAS(T) uchar x4_data[N * sizeof(T)];
 
 public:
   // typedef pointer_iterator< T, reserved_vector< T, N >, void > iterator;

--- a/include/types.h
+++ b/include/types.h
@@ -4,6 +4,14 @@
 #ifdef __cplusplus
 #include "static_assert.hpp"
 
+// MWCC 1.3.2 rejects template-dependent alignment attributes. Keep its original
+// layouts, and enforce the stored type's alignment on modern compilers.
+#ifdef __MWERKS__
+#define ALIGNAS(N)
+#else
+#define ALIGNAS(N) alignas(N)
+#endif
+
 extern "C" {
 #endif
 


### PR DESCRIPTION
Enforce payload alignment with ALIGNAS while preserving MWCC layouts because GC 1.3.2 rejects dependent alignment attributes.