### PR TITLE
Fix vector pop_back destruction

### DIFF
--- a/include/rstl/reserved_vector.hpp
+++ b/include/rstl/reserved_vector.hpp
@@ -63,7 +63,7 @@ public:
   }
 
   void pop_back() {
-    destroy(&data()[x0_count]);
+    destroy(&data()[x0_count - 1]);
     --x0_count;
   }
 

--- a/include/rstl/vector.hpp
+++ b/include/rstl/vector.hpp
@@ -93,7 +93,10 @@ public:
     ++x4_count;
   }
 
-  void pop_back() { --x4_count; }
+  void pop_back() {
+    destroy(xc_items + x4_count - 1);
+    --x4_count;
+  }
 
   inline vector& operator=(const vector& other);
 


### PR DESCRIPTION
Destroy the last live element in vector and reserved_vector; code, data, and resolved relocations remain unchanged across all six builds.