### PR TITLE
Restore abstract IObj bases and const access

### DIFF
--- a/include/Kyoto/IObj.hpp
+++ b/include/Kyoto/IObj.hpp
@@ -11,12 +11,14 @@ extern const SObjectTag gkInvalidObjectTag;
 
 class IObj {
 public:
-  virtual ~IObj() {}
+  virtual ~IObj() = 0;
 };
+
+inline IObj::~IObj() {}
 
 class CObjOwnerDerivedFromIObjUntyped : public IObj {
 public:
-  ~CObjOwnerDerivedFromIObjUntyped() {}
+  ~CObjOwnerDerivedFromIObjUntyped() = 0;
   template < typename T >
   CObjOwnerDerivedFromIObjUntyped(T* obj) : m_objPtr(obj) {}
   template < typename T >
@@ -27,6 +29,8 @@ public:
 protected:
   void* m_objPtr;
 };
+
+inline CObjOwnerDerivedFromIObjUntyped::~CObjOwnerDerivedFromIObjUntyped() {}
 
 template < typename T >
 class TObjOwnerDerivedFromIObj : public CObjOwnerDerivedFromIObjUntyped {

--- a/include/Kyoto/IObj.hpp
+++ b/include/Kyoto/IObj.hpp
@@ -24,7 +24,7 @@ public:
   template < typename T >
   CObjOwnerDerivedFromIObjUntyped(const rstl::auto_ptr< T >& obj) : m_objPtr(obj.release()) {}
 
-  void* GetContents() { return m_objPtr; }
+  void* GetContents() const { return m_objPtr; }
 
 protected:
   void* m_objPtr;

--- a/include/Kyoto/TToken.hpp
+++ b/include/Kyoto/TToken.hpp
@@ -30,7 +30,7 @@ public:
     return TObjOwnerDerivedFromIObj< T >::GetNewDerivedObject(obj);
   }
 
-  TToken< T > NonConstCopy() const { return *const_cast< TToken< T >* >(this); }
+  TToken< T > NonConstCopy() const { return *this; }
 };
 
 template < typename T >


### PR DESCRIPTION
Match the retail IObj and untyped-owner vtables by restoring pure virtual destructors; all six configured build and hash checks pass.