### PR TITLE
Match & link CPASAnimState

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1509,7 +1509,7 @@ config.libs = [
                 MatchingFor("GM8E01_00", "GM8E01_01", "GM8P01_00"),
                 "Kyoto/Animation/CPASAnimParm.cpp",
             ),
-            Object(NonMatching, "Kyoto/Animation/CPASAnimState.cpp"),
+            Object(MatchingFor("GM8E01_00", "GM8E01_01"), "Kyoto/Animation/CPASAnimState.cpp"),
             Object(MatchingFor("GM8E01_00", "GM8E01_01"), "Kyoto/Animation/CPASDatabase.cpp"),
             Object(
                 MatchingFor("GM8E01_00", "GM8E01_01"),

--- a/include/Kyoto/Animation/CPASAnimParm.hpp
+++ b/include/Kyoto/Animation/CPASAnimParm.hpp
@@ -36,7 +36,7 @@ public:
   bool GetBoolValue() const;
   int GetEnumValue() const;
 
-  UParmValue GetParameter() { return x0_value; }
+  const UParmValue& GetParameterValue() const { return x0_value; }
   EParmType GetParameterType() const { return x4_type; }
 
 private:

--- a/include/Kyoto/Animation/CPASAnimState.hpp
+++ b/include/Kyoto/Animation/CPASAnimState.hpp
@@ -20,6 +20,7 @@ public:
   CPASAnimState(CInputStream& in);
 
   CPASAnimParm GetAnimParmData(int, unsigned int) const;
+  void AddAnimParmData(int animId, const rstl::reserved_vector< CPASAnimParm, 8 >& parms);
   rstl::pair< float, int > FindBestAnimation(const rstl::reserved_vector< CPASAnimParm, 8 >& parms,
                                              CRandom16& random, int ignoreAnim) const;
 

--- a/src/Kyoto/Animation/CPASAnimState.cpp
+++ b/src/Kyoto/Animation/CPASAnimState.cpp
@@ -66,6 +66,19 @@ CPASAnimParm CPASAnimState::GetAnimParmData(int animId, uint parmIdx) const {
   return CPASAnimParm::NoParameter();
 }
 
+// The linker strips this entry point and retains its vector insertion helpers.
+void CPASAnimState::AddAnimParmData(
+    int animId, const rstl::reserved_vector< CPASAnimParm, 8 >& parms) {
+  rstl::reserved_vector< CPASAnimParm::UParmValue, 8 > values;
+  for (int i = 0; i < parms.size(); ++i) {
+    values.push_back(parms[i].GetParameterValue());
+  }
+
+  CPASAnimInfo animInfo(animId, values);
+  AUTO(it, rstl::lower_bound(x14_anims.begin(), x14_anims.end(), animInfo));
+  x14_anims.insert(it, animInfo);
+}
+
 rstl::pair< float, int >
 CPASAnimState::FindBestAnimation(const rstl::reserved_vector< CPASAnimParm, 8 >& parms,
                                  CRandom16& random, int ignoreAnim) const {

--- a/src/Kyoto/Animation/CPASParmInfo.cpp
+++ b/src/Kyoto/Animation/CPASParmInfo.cpp
@@ -6,8 +6,8 @@ CPASParmInfo::CPASParmInfo(CInputStream& in)
 : x0_type(CPASAnimParm::kPT_None)
 , x4_weightFunction(kWF_Invalid)
 , x8_weight(0.f)
-, xc_min(CPASAnimParm::FromInt32(0).GetParameter())
-, x10_max(CPASAnimParm::FromInt32(0).GetParameter()) {
+, xc_min(CPASAnimParm::FromInt32(0).GetParameterValue())
+, x10_max(CPASAnimParm::FromInt32(0).GetParameterValue()) {
 
   CPASAnimParm::EParmType type = CPASAnimParm::EParmType(in.ReadInt32());
   x0_type = type;


### PR DESCRIPTION
Restores the inferred stripped `AddAnimParmData` entry point and demo-named value getter, enabling exact linkage in both USA versions.
